### PR TITLE
fix: prevent iOS input focus zoom on search inputs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -213,3 +213,14 @@
   width: fit-content !important;
   max-width: none !important;
 }
+
+/* Prevent iOS Safari/WebKit auto-zoom on focus (<16px inputs).
+   -webkit-touch-callout = iOS WebKit only (Safari, iOS Chrome, iOS PWA).
+   any-pointer:coarse keeps the fix on iPads with mouse/trackpad attached. */
+@supports (-webkit-touch-callout: none) {
+  @media (any-pointer: coarse) {
+    .ios-no-zoom-input {
+      font-size: 16px;
+    }
+  }
+}

--- a/components/station-combobox.tsx
+++ b/components/station-combobox.tsx
@@ -131,7 +131,7 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
               onChange={(e) => setQuery(e.target.value)}
               placeholder={placeholder}
               dir="auto"
-              className="w-full rounded-md bg-muted px-3 py-2 text-sm outline-none placeholder:text-muted-foreground md:px-4 md:py-2.5 md:text-base"
+              className="ios-no-zoom-input w-full rounded-md bg-muted px-3 py-2 text-sm outline-none placeholder:text-muted-foreground md:px-4 md:py-2.5 md:text-base"
             />
           </div>
           <ul className="max-h-64 overflow-y-auto py-1">

--- a/components/stations-tab.tsx
+++ b/components/stations-tab.tsx
@@ -73,7 +73,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t.searchStations}
-          className="w-full rounded-xl border border-border bg-card py-3 ps-9 pe-3 text-sm outline-none ring-primary/30 focus:ring-2"
+          className="ios-no-zoom-input w-full rounded-xl border border-border bg-card py-3 ps-9 pe-3 text-sm outline-none ring-primary/30 focus:ring-2"
         />
       </div>
 


### PR DESCRIPTION
Fixes #7.

## What changed (3 files)

- `app/globals.css` — new targeted `.ios-no-zoom-input` utility, iOS WebKit only:
  ```css
  @supports (-webkit-touch-callout: none) {
    @media (any-pointer: coarse) {
      .ios-no-zoom-input { font-size: 16px; }
    }
  }
  ```
  Same stylesheet serves Safari + installed PWA, so both are covered. Viewport left unchanged (`device-width, initialScale:1, maximumScale:5, userScalable:true`); no `maximum-scale=1` / `user-scalable=no`.
- `components/station-combobox.tsx` — added `ios-no-zoom-input` to the route/station/place search `<input>` (was `text-sm`/14px on mobile).
- `components/stations-tab.tsx` — added `ios-no-zoom-input` to the station list filter `<input>` (was `text-sm`/14px always).

No other typography touched (labels, station names, badges, metadata unchanged). No `textarea`/`<select>` exist in the app.

Why `any-pointer: coarse` instead of `pointer`: `pointer` only describes the primary device, so an iPad with mouse/trackpad attached could lose the fix. `any-pointer: coarse` applies whenever a coarse touchscreen exists.

## Verification

- `pnpm test`: 98/98 passed (6 files).
- `pnpm build`: succeeded, 13 routes generated (only pre-existing warnings about `experimental.outputFileTracingIncludes` / turbopack root).
- `pnpm lint`: could not run — `eslint: not found` (pre-existing: `lint: eslint .` script exists but eslint is not in devDependencies).

## Manual test (iPhone)

- Before: `/` origin/destination search and `/stations` search zoom on focus.
- After: no zoom/shift in Safari or installed PWA (Add to Home Screen); desktop/Android visually unchanged; pinch-to-zoom still works.