### PR TITLE
fix: improve accessibility labels and keyboard focus

### DIFF
--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -158,6 +158,7 @@ export function HomePage() {
           <ExternalLink className="size-3 text-primary" />
           <span className="text-muted-foreground">{t.builtBy}</span>
           <span className="font-semibold text-foreground">aliinreallife</span>
+          <span className="sr-only"> ({t.opensInNewTab})</span>
         </a>
         <a
           href="https://github.com/mostafa-kheibary/tehran-metro-data"
@@ -170,6 +171,7 @@ export function HomePage() {
           <span className="font-semibold text-foreground">
             mostafa-kheibary
           </span>
+          <span className="sr-only"> ({t.opensInNewTab})</span>
         </a>
       </div>
     </div>
@@ -256,7 +258,7 @@ function RouteView({
               type="button"
               onClick={locateOrigin}
               disabled={locating}
-              aria-label="Use my location"
+              aria-label={t.useMyLocation}
               className="flex w-9 shrink-0 self-stretch items-center justify-center rounded-lg border border-border bg-background transition-colors hover:bg-accent disabled:opacity-50"
             >
               {locating ? (
@@ -361,6 +363,7 @@ function RouteView({
                   >
                     <MapPin className="size-3.5 shrink-0 md:size-4" />
                     <span className="truncate">{isFa ? "بریم به ایستگاه مبدا" : "Go to start"}</span>
+                    <span className="sr-only"> ({t.opensInNewTab})</span>
                   </a>
                   <button
                     type="button"

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -80,8 +80,12 @@ export function AppNav() {
           <button
             type="button"
             onClick={toggleLang}
-            className="flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-2 text-sm font-medium transition-colors hover:bg-accent md:px-3 md:py-2.5 md:text-base"
-            aria-label="Toggle language"
+            className="flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-2 text-sm font-medium transition-colors hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background md:px-3 md:py-2.5 md:text-base"
+            aria-label={
+              lang === "en"
+                ? "فارسی — Toggle language"
+                : "EN — تغییر زبان"
+            }
           >
             <Globe className="size-4 md:size-5" />
             {lang === "en" ? "فارسی" : "EN"}

--- a/components/station-card.tsx
+++ b/components/station-card.tsx
@@ -164,12 +164,13 @@ export function StationCard({ station, lang, distance, onSetDest, onShowTimetabl
           )}
           target="_blank"
           rel="noopener noreferrer"
-          aria-label={t.directions}
+          aria-label={`${t.directions} — ${t.opensInNewTab}`}
           title={t.directions}
           className="flex flex-1 items-center justify-center gap-1.5 border-x border-border px-2 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
           <MapPin className="size-3.5" />
           {t.directions}
+          <span className="sr-only"> ({t.opensInNewTab})</span>
         </a>
         <button
           type="button"

--- a/components/station-combobox.tsx
+++ b/components/station-combobox.tsx
@@ -91,7 +91,7 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 text-sm text-start transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring md:px-4 md:py-3 md:text-base"
+        className="flex w-full items-center gap-2 rounded-lg border border-input bg-background px-3 py-2.5 text-sm text-start transition-colors hover:bg-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background md:px-4 md:py-3 md:text-base"
       >
         <span className={cn("size-2.5 shrink-0 rounded-full", accentClass)} aria-hidden />
         <span className="min-w-0 flex-1 truncate">
@@ -108,7 +108,7 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
           <span
             role="button"
             tabIndex={0}
-            aria-label="Clear"
+            aria-label={t.clear}
             onClick={(e) => {
               e.stopPropagation()
               onChange(null)
@@ -131,7 +131,7 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
               onChange={(e) => setQuery(e.target.value)}
               placeholder={placeholder}
               dir="auto"
-              className="ios-no-zoom-input w-full rounded-md bg-muted px-3 py-2 text-sm outline-none placeholder:text-muted-foreground md:px-4 md:py-2.5 md:text-base"
+              className="ios-no-zoom-input w-full rounded-md bg-muted px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background md:px-4 md:py-2.5 md:text-base"
             />
           </div>
           <ul className="max-h-64 overflow-y-auto py-1">

--- a/components/stations-tab.tsx
+++ b/components/stations-tab.tsx
@@ -73,7 +73,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t.searchStations}
-          className="ios-no-zoom-input w-full rounded-xl border border-border bg-card py-3 ps-9 pe-3 text-sm outline-none ring-primary/30 focus:ring-2"
+          className="ios-no-zoom-input w-full rounded-xl border border-border bg-card py-3 ps-9 pe-3 text-sm outline-none ring-primary/30 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         />
       </div>
 

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -92,6 +92,7 @@ export const STRINGS = {
     shareRoute: "Share route",
     shareStation: "Share station",
     copied: "Link copied!",
+    opensInNewTab: "opens in new tab",
   },
   fa: {
     appTitle: "متو",
@@ -184,6 +185,7 @@ export const STRINGS = {
     shareRoute: "اشتراک‌گذاری مسیر",
     shareStation: "اشتراک‌گذاری ایستگاه",
     copied: "لینک کپی شد!",
+    opensInNewTab: "در برگه جدید باز می‌شود",
   },
 } as const;
 


### PR DESCRIPTION
Closes #9

#### Summary

- Fix language-toggle accessible name (`app/nav.tsx`): visible label now included and localized (`فارسی — Toggle language` / `EN — تغییر زبان`); added missing keyboard `focus-visible` ring
- Add/normalize keyboard `focus-visible` indicators: combobox trigger `focus:` → `focus-visible:` plus `ring-offset`; no global `outline-none` removal
- Restore visible focus for search/combobox inputs (`components/stations-tab.tsx`, `components/station-combobox.tsx`) while preserving existing appearance
- Localize `Clear` (`aria-label={t.clear}`, structure unchanged to avoid nested `<button>`) and `Use my location` (`aria-label={t.useMyLocation}`)
- Add localized `opensInNewTab` key to `STRINGS` (`lib/i18n.ts`) and announce new tabs via `sr-only` text on all 4 external links; `rel="noopener noreferrer"` kept
- Preserve existing visual design, RTL/LTR behavior, localization, and PWA behavior

#### Verification

- `pnpm test` — 6 files / 98 tests passed
- `pnpm build` — successful
- `pnpm lint` — cannot currently run because ESLint is not installed/resolvable in the existing repo setup (pre-existing, not fixed here)
- `npx tsc --noEmit` — still reports 6 pre-existing errors in MCP/Base UI-related code (`app/api/mcp/route.ts`, `mcp-server.ts`, `components/ui/button.tsx`); none introduced in the files changed by this patch

Lint and TypeScript failures are pre-existing and out of scope for this PR.

#### Out of scope

- No color/palette changes
- No WCAG AAA remediation (AA remains the target; PowerMapper green-background calculations did not match actual theme variables)
- No MCP/type-system cleanup
- No ESLint/tooling setup changes
- No redesign/refactor