### PR TITLE
fix(typography): consistent Persian font, digits, and tabular numerals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -166,6 +166,18 @@
   html {
     @apply font-sans;
   }
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+}
+
+/* Tabular Persian numerals: keeps times like ۱۵:۱۱ aligned
+   in Vazirmatn without switching to a monospace font. */
+.tnum {
+  font-variant-numeric: tabular-nums;
 }
 
 .station-label {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ import "./globals.css";
 const vazirmatn = Vazirmatn({
   variable: "--font-vazirmatn",
   subsets: ["arabic", "latin"],
-  weight: ["400", "700"],
+  weight: "variable",
 });
 
 const siteUrl = "https://metto.ir";

--- a/components/route-panel.tsx
+++ b/components/route-panel.tsx
@@ -233,7 +233,7 @@ function Stat({
   return (
     <div className="flex flex-col items-center gap-1 rounded-xl border border-border bg-card px-3 py-3 md:px-5 md:py-4">
       <span className="text-muted-foreground">{icon}</span>
-      <span className="text-2xl font-bold leading-none md:text-3xl" title={tooltip}>{value}</span>
+      <span className="tnum text-2xl font-bold leading-none md:text-3xl" title={tooltip}>{value}</span>
       <span className="text-sm text-muted-foreground md:text-base">{label}</span>
     </div>
   );
@@ -285,8 +285,8 @@ function SegmentCard({
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <span className="text-2xl font-bold font-mono leading-none md:text-3xl" style={{ color }}>
-                {trip ? trip.departTime : next?.time ?? "—"}
+              <span className="tnum text-2xl font-bold leading-none md:text-3xl" style={{ color }}>
+                {persianDigits(trip ? trip.departTime : (next?.time ?? "—"), lang)}
               </span>
               {(trip?.train.isExpress || next?.isExpress) && (
                 <span className="flex items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-bold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
@@ -300,7 +300,7 @@ function SegmentCard({
               {trip ? (
                 <>
                   <span className="mx-1.5">·</span>
-                  {isFa ? "رسیدن" : "arrive"} <span className="font-mono font-semibold">{persianDigits(trip.arriveTime, lang)}</span>
+                  {isFa ? "رسیدن" : "arrive"} <span className="tnum font-semibold">{persianDigits(trip.arriveTime, lang)}</span>
                   <span className="mx-1.5">·</span>
                   {persianDigits(trip.travelMinutes, lang)}{isFa ? " دقیقه" : " min"}
                 </>
@@ -317,7 +317,7 @@ function SegmentCard({
               return (
                 <p className="mt-0.5 text-[11px] text-muted-foreground">
                   {isFa ? "بعدی:" : "Then:"}{" "}
-                  <span className="font-mono font-semibold">{persianDigits(nextDifferent.time, lang)}</span>
+                  <span className="tnum font-semibold">{persianDigits(nextDifferent.time, lang)}</span>
                   {nextDifferent.isExpress && (
                     <span className="ms-1 text-amber-600 dark:text-amber-400">
                       ({isFa ? "سریع السیر" : "express"})

--- a/components/station-card.tsx
+++ b/components/station-card.tsx
@@ -125,8 +125,8 @@ export function StationCard({ station, lang, distance, onSetDest, onShowTimetabl
                 >
                   {persianDigits(g.line, lang)}
                 </span>
-                <span className="font-mono font-semibold">
-                  {g.departures[0]?.time}
+                <span className="tnum font-semibold">
+                  {g.departures[0]?.time ? persianDigits(g.departures[0].time, lang) : null}
                 </span>
                 {g.departures[0]?.isExpress && (
                   <span className="flex items-center gap-0.5 text-amber-600 dark:text-amber-400">
@@ -135,8 +135,8 @@ export function StationCard({ station, lang, distance, onSetDest, onShowTimetabl
                   </span>
                 )}
                 {g.departures.length > 1 && (
-                  <span className="text-muted-foreground text-[10px]">
-                    {isFa ? "بعدی:" : "+"} {g.departures[1]?.time}
+                  <span className="tnum text-muted-foreground text-[10px]">
+                    {isFa ? "بعدی:" : "+"} {g.departures[1]?.time ? persianDigits(g.departures[1].time, lang) : null}
                   </span>
                 )}
               </div>

--- a/components/station-detail.tsx
+++ b/components/station-detail.tsx
@@ -134,7 +134,7 @@ function DepartureRow({ dep, lang }: { dep: Departure; lang: Lang }) {
         {persianDigits(dep.line, lang)}
       </span>
       <Clock className="size-3 shrink-0 text-muted-foreground" />
-      <span className="font-mono font-semibold">{dep.time}</span>
+      <span className="tnum font-semibold">{persianDigits(dep.time, lang)}</span>
       {dep.isExpress && (
         <span className="flex items-center gap-0.5 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-bold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
           <Zap className="size-2.5" />

--- a/components/station-timesheet.tsx
+++ b/components/station-timesheet.tsx
@@ -201,8 +201,8 @@ export function StationTimesheet({
               <span className="text-sm font-semibold">
                 {t.line} {persianDigits(lineData.line, lang)}
               </span>
-              <span className="ml-auto text-xs text-muted-foreground">
-                {totalCount}{" "}
+              <span className="tnum ml-auto text-xs text-muted-foreground">
+                {persianDigits(totalCount, lang)}{" "}
                 {isFa ? "حرکت" : "trains"}
               </span>
               <ChevronDown
@@ -226,14 +226,14 @@ export function StationTimesheet({
                         <span
                           key={i}
                           className={cn(
-                            "inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-xs font-mono",
+                            "tnum inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-xs",
                             tt.isExpress
                               ? "bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400"
                               : "bg-muted text-foreground",
                           )}
                         >
                           {tt.isExpress && <Zap className="size-2.5" />}
-                          {tt.time}
+                          {persianDigits(tt.time, lang)}
                         </span>
                       ))}
                     </div>

--- a/i18n.test.ts
+++ b/i18n.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { persianDigits } from "./lib/i18n";
+
+describe("persianDigits locale behavior", () => {
+  it('converts Latin digits to Persian in fa UI ("15:11" -> "۱۵:۱۱")', () => {
+    expect(persianDigits("15:11", "fa")).toBe("۱۵:۱۱");
+  });
+
+  it('keeps Latin digits in en UI ("15:11" stays "15:11")', () => {
+    expect(persianDigits("15:11", "en")).toBe("15:11");
+  });
+});


### PR DESCRIPTION
Closes #11

## Summary

- Load Vazirmatn as a variable font so 400/500/600/700 weights are real rather than synthesized (previously only 400/700 were loaded while the UI uses 500/600)
- Use Vazirmatn + tabular numerals (`.tnum`, `font-variant-numeric: tabular-nums`) instead of monospace for user-facing times
- Convert user-facing Persian times/counts with the existing `persianDigits()` helper (`15:11` → `۱۵:۱۱`, `7` → `۷`)
- Retain Latin digits for English UI and machine-readable API/URL/coordinate values
- Make form controls inherit the app font (`button, input, select, textarea { font: inherit; }`)
- Add locale digit tests (`i18n.test.ts`)

## Verification

- `pnpm test`: 7 files / 100 tests pass (incl. 2 new locale digit tests)
- `pnpm build`: passes
- `pnpm exec tsc --noEmit`: only pre-existing unrelated errors (`app/api/mcp/route.ts` argsSchema, `mcp-server.ts` argsSchema, `components/ui/button.tsx` missing `@base-ui/react/button`); none in changed files
- `pnpm lint`: unavailable, eslint is not installed (pre-existing)