### PR TITLE
fix(map): restore dark minimalist basemap

### DIFF
--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -44,7 +44,7 @@ const SATELLITE_ATTR = 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, U
 const LABELS_URL = "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}"
 const CARTO_KEY = process.env.NEXT_PUBLIC_CARTO_BASEMAP_KEY
 const MINIMALIST_URL =
-  `https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png?key=${CARTO_KEY}`
+  `https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png?key=${CARTO_KEY}`
 const MINIMALIST_ATTR =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>'
 


### PR DESCRIPTION
Restores the CARTO dark minimalist basemap (`dark_nolabels`) for the minimalist map mode, reverting the light-basemap change.

Single-line change in `components/real-map.tsx`.

Verification:
- `pnpm test`: 7 files / 100 tests pass
- `pnpm build`: passes