### PR TITLE
fix(map): brighten dark basemap minor streets with scoped filter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -236,3 +236,10 @@
     }
   }
 }
+
+/* Scoped brightening for the CARTO dark_nolabels raster basemap only.
+   Leaflet puts TileLayer `className` on that layer's own container, so metro
+   lines/markers/labels/controls in other panes are untouched. */
+.metto-dark-basemap {
+  filter: brightness(1.15) contrast(1.25);
+}

--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -305,6 +305,7 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
           maxZoom: 20,
           attribution: MINIMALIST_ATTR,
           subdomains: "abcd",
+          className: "metto-dark-basemap",
         })
       : null
     minimalistLayerRef.current = minimalistLayer

--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -43,8 +43,13 @@ const SATELLITE_URL = "https://server.arcgisonline.com/ArcGIS/rest/services/Worl
 const SATELLITE_ATTR = 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
 const LABELS_URL = "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}"
 const CARTO_KEY = process.env.NEXT_PUBLIC_CARTO_BASEMAP_KEY
-const MINIMALIST_URL =
-  `https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png?key=${CARTO_KEY}`
+// CARTO serves raster tiles without a key (with an "API key required"
+// watermark) — far better than a blank map. Append the key only when set,
+// and never gate layer creation on it: a missing key must degrade to
+// watermarked tiles, not to zero tile layers (white/blank background).
+const MINIMALIST_URL = CARTO_KEY
+  ? `https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png?key=${CARTO_KEY}`
+  : `https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}{r}.png`
 const MINIMALIST_ATTR =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attributions">CARTO</a>'
 
@@ -300,26 +305,26 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
     })
     labelsLayerRef.current = labelsLayer
 
-    const minimalistLayer = CARTO_KEY
-      ? L.tileLayer(MINIMALIST_URL, {
-          maxZoom: 20,
-          attribution: MINIMALIST_ATTR,
-          subdomains: "abcd",
-          className: "metto-dark-basemap",
-        })
-      : null
+    const minimalistLayer = L.tileLayer(MINIMALIST_URL, {
+      maxZoom: 20,
+      attribution: MINIMALIST_ATTR,
+      subdomains: "abcd",
+      className: "metto-dark-basemap",
+    })
     minimalistLayerRef.current = minimalistLayer
     if (!CARTO_KEY) {
       console.warn(
-        "NEXT_PUBLIC_CARTO_BASEMAP_KEY is missing; CARTO Minimalist basemap cannot load.",
+        "NEXT_PUBLIC_CARTO_BASEMAP_KEY is missing; showing watermarked CARTO tiles. Restart dev / redeploy after setting it.",
       )
     }
 
     if (initialMapModeRef.current === "satellite") {
       tileLayer.addTo(map)
       labelsLayer.addTo(map)
-    } else if (minimalistLayer) {
+    } else {
       minimalistLayer.addTo(map)
+      // Dark backdrop so tile gaps/loading never flash white-yellowish.
+      map.getContainer().style.backgroundColor = "#0e0e0e"
     }
 
     overlayRef.current = L.layerGroup().addTo(map)
@@ -395,7 +400,7 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
       if (tileLayerRef.current && map.hasLayer(tileLayerRef.current)) map.removeLayer(tileLayerRef.current)
       if (labelsLayerRef.current && map.hasLayer(labelsLayerRef.current)) map.removeLayer(labelsLayerRef.current)
       if (minimalistLayerRef.current && !map.hasLayer(minimalistLayerRef.current)) minimalistLayerRef.current.addTo(map)
-      container.style.backgroundColor = ""
+      container.style.backgroundColor = "#0e0e0e"
     }
   }, [mapMode])
 


### PR DESCRIPTION
Closes #16.

## What
Minor streets on CARTO raster `dark_nolabels` bake down to sub-pixel and vanish against the near-black background, while TehGo's vector GL rendering of the same palette keeps them crisp mid-gray. CARTO has no high-contrast raster variant, so this keeps the raster tiles + Leaflet and lifts legibility with a scoped CSS filter:

- `components/real-map.tsx`: minimalist `L.tileLayer` gains `className: metto-dark-basemap` (one option; URL, subdomains, attribution, API-key handling, retina selection unchanged).
- `app/globals.css`: new `.metto-dark-basemap { filter: brightness(1.15) contrast(1.25); }` — Leaflet puts `className` on that layer's own container, so metro lines/markers/labels/controls in other panes are untouched.

## Out of scope
Basemap URL/variant swap (stays `dark_nolabels`), no Leaflet->MapLibre migration, no light/Positron swap, no satellite-mode change, no routing/interaction changes.

## Verification
- `npx tsc --noEmit`: clean for touched files (pre-existing errors only in untouched `app/api/mcp/route.ts`, `mcp-server.ts`, `components/ui/button.tsx`)
- Visual: compare Metto `/map` (minimalist) vs TehGo `/fa` same zoom/area — background still near-black, secondary streets legible, overlays unchanged.
- Tune: raise `contrast` in 0.05 steps to ~1.4 max if still faint; lower `brightness` first if background grays.