### PR TITLE
fix(layout): contain nested scroll and clear bottom tab bar

### DIFF
--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -231,7 +231,7 @@ function RouteView({
   }
 
   return (
-    <div className="flex size-full flex-col overflow-y-auto p-4 md:items-center md:p-8 lg:p-10">
+    <div className="flex size-full flex-col overflow-y-auto overscroll-contain p-4 md:items-center md:p-8 lg:p-10">
       <div className="flex w-full max-w-xl flex-col gap-4 md:max-w-2xl md:gap-5">
         <div className="flex flex-col gap-2.5">
           <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground md:text-sm">

--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -231,7 +231,7 @@ function RouteView({
   }
 
   return (
-    <div className="flex size-full flex-col overflow-y-auto overscroll-contain p-4 md:items-center md:p-8 lg:p-10">
+    <div className="flex size-full flex-col overflow-y-auto overflow-x-hidden overscroll-contain p-4 md:items-center md:p-8 lg:p-10">
       <div className="flex w-full max-w-xl flex-col gap-4 md:max-w-2xl md:gap-5">
         <div className="flex flex-col gap-2.5">
           <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground md:text-sm">

--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -146,7 +146,7 @@ export function HomePage() {
         />
       </div>
 
-      <div className="z-20 flex items-center justify-start gap-4 border-t border-border bg-card/90 px-4 py-2 backdrop-blur">
+      <div className="z-20 flex flex-wrap items-center justify-start gap-x-4 gap-y-1 border-t border-border bg-card/90 px-4 py-2 backdrop-blur">
         <a
           href="https://github.com/aliinreallife"
           target="_blank"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -187,7 +187,7 @@ export default function RootLayout({
         >
           <MetroProvider>
             <AppNav />
-            <div className="relative min-h-0 flex-1 flex flex-col pb-14 md:pb-0">{children}</div>
+            <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden pb-16 pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">{children}</div>
           </MetroProvider>
         </FingerprintProvider>
         {process.env.NODE_ENV === "production" && <Analytics />}

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -94,7 +94,7 @@ export function AppNav() {
       </header>
 
       {/* mobile bottom tab bar - fixed to viewport bottom */}
-      <nav className="fixed bottom-0 inset-x-0 z-20 grid grid-cols-4 border-t border-border bg-card/90 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden">
+      <nav className="fixed bottom-0 inset-x-0 z-20 grid grid-cols-4 border-t border-border bg-card pb-[env(safe-area-inset-bottom)] md:hidden">
         {NAV_ITEMS.map((item) => {
           const href = getHref(item.href);
           const active = currentPath === item.href;

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -94,7 +94,7 @@ export function AppNav() {
       </header>
 
       {/* mobile bottom tab bar - fixed to viewport bottom */}
-      <nav className="fixed bottom-0 inset-x-0 z-20 grid grid-cols-4 border-t border-border bg-card/90 backdrop-blur md:hidden">
+      <nav className="fixed bottom-0 inset-x-0 z-20 grid grid-cols-4 border-t border-border bg-card/90 pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden">
         {NAV_ITEMS.map((item) => {
           const href = getHref(item.href);
           const active = currentPath === item.href;

--- a/components/nearby-tab.tsx
+++ b/components/nearby-tab.tsx
@@ -100,7 +100,7 @@ export function NearbyTab({ lang, onSetOrigin, onSetDest }: Props) {
         : "";
 
   return (
-    <div className="flex size-full min-h-0 flex-col overflow-y-auto bg-background">
+    <div className="flex size-full min-h-0 flex-col overflow-y-auto overscroll-contain bg-background">
       <div className="mx-auto flex w-full max-w-xl flex-col gap-4 p-4">
         {/* Location setter */}
         <section className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">

--- a/components/nearby-tab.tsx
+++ b/components/nearby-tab.tsx
@@ -100,7 +100,7 @@ export function NearbyTab({ lang, onSetOrigin, onSetDest }: Props) {
         : "";
 
   return (
-    <div className="flex size-full min-h-0 flex-col overflow-y-auto overscroll-contain bg-background">
+    <div className="flex size-full min-h-0 flex-col overflow-y-auto overflow-x-hidden overscroll-contain bg-background">
       <div className="mx-auto flex w-full max-w-xl flex-col gap-4 p-4">
         {/* Location setter */}
         <section className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4">

--- a/components/stations-tab.tsx
+++ b/components/stations-tab.tsx
@@ -66,7 +66,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
   }, [query, lineFilter, isFa, branchIndex, isForked, lineOrder]);
 
   return (
-    <div className="mx-auto flex h-full w-full max-w-xl flex-col gap-4 p-4">
+    <div className="mx-auto flex h-full w-full max-w-xl flex-col gap-4 overflow-x-hidden p-4">
       <div className="relative">
         <Search className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
         <input
@@ -128,7 +128,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
         {persianDigits(results.length, lang)} {isFa ? "ایستگاه" : "stations"}
       </p>
 
-      <ul className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain pb-2">
+      <ul className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overflow-x-hidden overscroll-contain pb-2">
         {results.length === 0 && (
           <li className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
             {t.noResults}

--- a/components/stations-tab.tsx
+++ b/components/stations-tab.tsx
@@ -106,7 +106,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
           <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             {t.towards}
           </p>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {lineOrder.terminals.map((termId, i) => {
               const s = getStation(termId);
               const label = s ? (isFa ? s.name.fa : s.name.en) : termId;
@@ -128,7 +128,7 @@ export function StationsTab({ lang, onSetOrigin, onSetDest }: Props) {
         {persianDigits(results.length, lang)} {isFa ? "ایستگاه" : "stations"}
       </p>
 
-      <ul className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto pb-2">
+      <ul className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain pb-2">
         {results.length === 0 && (
           <li className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">
             {t.noResults}


### PR DESCRIPTION
Closes #20.

## Root cause (from your screenshots + local repro with headless Chromium + CDP)
1. The credits footer rendered two `shrink-0 whitespace-nowrap` links with no wrap (~430px in Persian on a 320-390px viewport), overflowing the page and spawning a document-level scroller behind the double-scroll + ghosted footer text.
2. The black slab between cards: on classic-scrollbar setups a 1-2px horizontal overflow (font-rendering differences) spawns a dark horizontal scrollbar at the list container's bottom edge, peeking above the old *translucent* tab bar — with card content ghosting through the blur beneath it. Local DOM audit (element-by-element rect/bg scan at the exact Ebn-e Sina spot) confirmed no black element exists in clean renders, pointing at scrollbar/translucency rather than content.

## What (all one-line class changes, no redesign of content)
- `app/home-page.tsx`: credits footer wraps (`flex-wrap`); RouteView scroller gets `overflow-x-hidden`.
- `app/layout.tsx`: wrapper `overflow-hidden` + clearance `pb-14` -> `pb-16` + safe-area (fallback included).
- `components/stations-tab.tsx` / `nearby-tab.tsx`: `overscroll-contain` + `overflow-x-hidden` on scrollers; branch-terminal chips wrap.
- `app/nav.tsx`: tab bar opaque `bg-card` (was translucent `bg-card/90 backdrop-blur`) + safe-area inset — nothing can ghost through it anymore.

## Verification
- Headless Chromium repro (390px, dark): DOM audit clean, vitest 100/100, `next build` success, tsc clean for touched files.
- Please re-check on your phone: stations list smooth, no black slab, footer single/double tidy rows, single scroll on home.