### PR TITLE
fix(build): top-level tracing, pinned roots, static schedule read, SDK argsSchema

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -260,10 +260,10 @@ function createServer() {
 
   server.registerPrompt("plan-route", {
     description: "Plan a metro route between two stations",
-    arguments: [
-      { name: "origin", description: "Starting station name (English or Farsi)", required: true },
-      { name: "destination", description: "Ending station name (English or Farsi)", required: true },
-    ],
+    argsSchema: {
+      origin: z.string().describe("Starting station name (English or Farsi)"),
+      destination: z.string().describe("Ending station name (English or Farsi)"),
+    },
   }, async ({ origin, destination }) => ({
     messages: [{
       role: "user" as const,
@@ -273,9 +273,9 @@ function createServer() {
 
   server.registerPrompt("station-info", {
     description: "Get detailed information about a metro station",
-    arguments: [
-      { name: "station", description: "Station name (English or Farsi)", required: true },
-    ],
+    argsSchema: {
+      station: z.string().describe("Station name (English or Farsi)"),
+    },
   }, async ({ station }) => ({
     messages: [{
       role: "user" as const,
@@ -285,10 +285,10 @@ function createServer() {
 
   server.registerPrompt("find-nearest", {
     description: "Find the nearest metro station to a location",
-    arguments: [
-      { name: "latitude", description: "Latitude coordinate", required: true },
-      { name: "longitude", description: "Longitude coordinate", required: true },
-    ],
+    argsSchema: {
+      latitude: z.string().describe("Latitude coordinate"),
+      longitude: z.string().describe("Longitude coordinate"),
+    },
   }, async ({ latitude, longitude }) => ({
     messages: [{
       role: "user" as const,

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { Button as ButtonPrimitive } from '@base-ui/react/button'
+import type * as React from 'react'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
@@ -45,9 +45,9 @@ function Button({
   variant = 'default',
   size = 'default',
   ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+}: React.ComponentProps<'button'> & VariantProps<typeof buttonVariants>) {
   return (
-    <ButtonPrimitive
+    <button
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}

--- a/lib/schedule-server.ts
+++ b/lib/schedule-server.ts
@@ -49,9 +49,19 @@ export function ensureServerScheduleData(
   if (scheduleLoadPromise) return scheduleLoadPromise;
   scheduleLoadPromise = (async () => {
     try {
-      const filePath =
-        scheduleFilePath ?? path.join(process.cwd(), "public", "schedule-data.json");
-      const raw = await readFile(filePath, "utf8");
+      let raw: string;
+      if (scheduleFilePath !== undefined) {
+        // Test-only seam (production callers never pass a custom path).
+        // Marked turbopackIgnore so NFT tracing only sees the static
+        // production path below; the file is still bundled via
+        // outputFileTracingIncludes in next.config.mjs.
+        raw = await readFile(/* turbopackIgnore: true */ scheduleFilePath, "utf8");
+      } else {
+        raw = await readFile(
+          path.join(process.cwd(), "public", "schedule-data.json"),
+          "utf8",
+        );
+      }
       const data: unknown = JSON.parse(raw);
       if (!Array.isArray(data)) throw new Error("schedule-data.json is not an array");
       setServerScheduleData(data as LineScheduleData[]);

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -264,10 +264,10 @@ server.registerResource("lines", "metro://lines", {
 
 server.registerPrompt("plan-route", {
   description: "Plan a metro route between two stations",
-  arguments: [
-    { name: "origin", description: "Starting station name", required: true },
-    { name: "destination", description: "Ending station name", required: true },
-  ],
+  argsSchema: {
+    origin: z.string().describe("Starting station name"),
+    destination: z.string().describe("Ending station name"),
+  },
 }, async ({ origin, destination }) => ({
   messages: [{
     role: "user" as const,
@@ -277,9 +277,9 @@ server.registerPrompt("plan-route", {
 
 server.registerPrompt("station-info", {
   description: "Get info about a metro station",
-  arguments: [
-    { name: "station", description: "Station name", required: true },
-  ],
+  argsSchema: {
+    station: z.string().describe("Station name"),
+  },
 }, async ({ station }) => ({
   messages: [{
     role: "user" as const,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,21 +1,28 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   images: {
     unoptimized: true,
+  },
+  // Pin Turbopack + output tracing to this project. Without this, Next
+  // infers the workspace root from the outermost lockfile (currently
+  // /home/ali/pnpm-lock.yaml) instead of /home/ali/tehran-metro-app.
+  outputFileTracingRoot: __dirname,
+  turbopack: {
+    root: __dirname,
   },
   // schedule-data.json is read from disk at runtime (node:fs) by the
   // route/MCP handlers. Static tracing cannot see the dynamic path, so
   // include it explicitly in those server function bundles — otherwise
   // Vercel serves the functions without the file and routing silently
   // falls back to geometric estimates.
-  experimental: {
-    outputFileTracingIncludes: {
-      "/api/route": ["./public/schedule-data.json"],
-      "/api/mcp": ["./public/schedule-data.json"],
-    },
+  outputFileTracingIncludes: {
+    "/api/route": ["./public/schedule-data.json"],
+    "/api/mcp": ["./public/schedule-data.json"],
   },
   // Canonical MCP endpoint is /mcp; /api/mcp stays as a backwards-compatible
   // alias. Internal rewrite (not redirect) so POST/streaming/GET transport

--- a/schedule-server.test.ts
+++ b/schedule-server.test.ts
@@ -209,4 +209,15 @@ describe("next.config tracing", () => {
     expect(config).toContain("/api/mcp");
     expect(config).toContain("public/schedule-data.json");
   });
+
+  it("keeps outputFileTracingIncludes top-level (not experimental) and pins the project root", () => {
+    const config = readFileSync(
+      join(process.cwd(), "next.config.mjs"),
+      "utf8",
+    );
+    expect(config).not.toMatch(/experimental\s*:\s*\{[^}]*outputFileTracingIncludes/);
+    expect(config).toContain("outputFileTracingRoot");
+    expect(config).toContain("turbopack");
+    expect(config).toMatch(/root\s*:\s*__dirname/);
+  });
 });


### PR DESCRIPTION
Fixes #25.

## What changed
- **next.config.mjs**: `experimental.outputFileTracingIncludes` -> top-level; added `outputFileTracingRoot` + `turbopack.root` pinned to project dir (stray `/home/ali/pnpm-lock.yaml` no longer hijacks the workspace root); removed `typescript.ignoreBuildErrors`.
- **lib/schedule-server.ts**: production fs read is now statically scoped `readFile(path.join(process.cwd(), "public", "schedule-data.json"))`; optional custom path kept as test-only seam with `/* turbopackIgnore: true */`.
- **mcp-server.ts, app/api/mcp/route.ts**: `registerPrompt` legacy `arguments: [...]` -> `argsSchema` with zod schemas (matches installed SDK 1.29). Prompt names/descriptions/callbacks unchanged.
- **components/ui/button.tsx**: dropped uninstalled `@base-ui/react/button` import; native `<button>` with same variants API. No callers affected, no new dependency.
- **schedule-server.test.ts**: regression test keeps tracing top-level and roots pinned.

## Verification
- `pnpm exec tsc --noEmit` -> EXIT 0
- `pnpm test` -> 8 files, 108 tests passed
- `pnpm build` -> EXIT 0, runs TypeScript validation (no skip), no invalid-config / workspace-root / NFT warnings. Both `/api/route` and `/api/mcp` NFT bundles include `public/schedule-data.json` (105 files each, no `next.config`).

## Notes
- No route, API, schedule, UI, PWA, SEO, or runtime behavior changes.
- `/home/ali/pnpm-lock.yaml` left untouched for manual cleanup.