### PR TITLE
Fix map reconnect, offline banner, and offline tab navigation

### DIFF
--- a/app/api/connectivity/route.ts
+++ b/app/api/connectivity/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+// Tiny reachability probe for effective-connectivity detection.
+//
+// `navigator.onLine` only reflects link state (useless with e.g. an Android
+// VPN virtual interface up but Wi-Fi/cellular off), so the client verifies
+// usable Internet by requesting this endpoint. Exactly HTTP 204 counts as
+// reachable — anything else (redirects, auth walls, errors) does not.
+//
+// Deliberately boring: no DB, no Redis, no external calls, no auth, no
+// body, no analytics, no side effects. `Cache-Control: no-store` plus the
+// service worker's existing NetworkOnly `/api/*` rule mean no layer may
+// ever satisfy this from cache — every success proves a live round trip.
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Cache-Control": "no-store, no-cache, must-revalidate",
+    },
+  });
+}

--- a/app/map/client.tsx
+++ b/app/map/client.tsx
@@ -7,6 +7,7 @@ import { Loader2, Layers, Satellite, Building2, AlertTriangle, X, WifiOff } from
 import { useMetro } from "@/app/providers";
 import { STATION_MAP, findRoute } from "@/lib/route";
 import { useHolidayData } from "@/lib/holidays/use-holiday-data";
+import { useConnectivity } from "@/lib/offline/use-connectivity";
 import { STRINGS } from "@/lib/i18n";
 import {
   haversineKm,
@@ -108,20 +109,41 @@ export function MapPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(initialParams.station);
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(new Set());
-  const [isOffline, setIsOffline] = useState(
-    () => typeof navigator !== "undefined" && navigator.onLine === false,
-  );
+  // Shared connectivity state (mount + online/offline + pageshow +
+  // foreground resync), so the banner reflects real network state even
+  // after the PWA resumes from background — never tile-error state.
+  const online = useConnectivity();
+  const isOffline = !online;
 
+  // One-time informational save notice: shown once per device while online,
+  // remembered locally. Never stacked with the offline banner, never a
+  // warning, no retention promises or implementation details.
+  const [saveNoticeSeen, setSaveNoticeSeen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem("metto.mapSaveNoticeSeen") === "1";
+    } catch {
+      return true;
+    }
+  });
+  const [saveNoticeDismissed, setSaveNoticeDismissed] = useState(false);
   useEffect(() => {
-    const onOnline = () => setIsOffline(false);
-    const onOffline = () => setIsOffline(true);
-    window.addEventListener("online", onOnline);
-    window.addEventListener("offline", onOffline);
-    return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener("offline", onOffline);
-    };
-  }, []);
+    if (online && !saveNoticeSeen) {
+      try {
+        localStorage.setItem("metto.mapSaveNoticeSeen", "1");
+      } catch {
+        // Private mode etc. — notice simply shows again next visit.
+      }
+    }
+  }, [online, saveNoticeSeen]);
+  const showSaveNotice = online && !saveNoticeSeen && !saveNoticeDismissed;
+  function dismissSaveNotice() {
+    setSaveNoticeDismissed(true);
+    try {
+      localStorage.setItem("metto.mapSaveNoticeSeen", "1");
+    } catch {
+      // Ignore.
+    }
+  }
 
   // A dismissed card stays dismissed for this search; a new search (URL change) brings cards back.
   useEffect(() => {
@@ -158,13 +180,36 @@ export function MapPage() {
         placeMarkers={placeMarkers}
       />
 
-      {/* Offline basemap notice: vectors still render, tiles need Internet. */}
+      {/* Offline notice: purely connectivity-driven (never tile-error
+          state), so it shows even when cached tiles render fine, hides on
+          reconnect, and never flickers per tile. */}
       {isOffline && (
         <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur">
           <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <p className="min-w-0 flex-1 text-muted-foreground">
-            {t.mapOfflineNote}
-          </p>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
+            <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
+          </div>
+        </div>
+      )}
+
+      {/* One-time save notice: informational only, online only, never
+          stacked with the offline banner. */}
+      {showSaveNotice && (
+        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
+          <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
+            <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
+          </div>
+          <button
+            type="button"
+            onClick={dismissSaveNotice}
+            aria-label={t.close}
+            className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
       )}
 

--- a/app/map/client.tsx
+++ b/app/map/client.tsx
@@ -118,14 +118,20 @@ export function MapPage() {
   // One-time informational save notice: shown once per device while online,
   // remembered locally. Never stacked with the offline banner, never a
   // warning, no retention promises or implementation details.
-  const [saveNoticeSeen, setSaveNoticeSeen] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem("metto.mapSaveNoticeSeen") === "1";
-    } catch {
-      return true;
-    }
-  });
+  // Hydration-safe: deterministic hidden initial on SSR AND first client
+  // render; localStorage is read only post-hydration. First-visit notice
+  // appearing after mount is intended; SSR/client markup must agree.
+  const [saveNoticeSeen, setSaveNoticeSeen] = useState<boolean>(true);
   const [saveNoticeDismissed, setSaveNoticeDismissed] = useState(false);
+  useEffect(() => {
+    try {
+      if (localStorage.getItem("metto.mapSaveNoticeSeen") !== "1") {
+        setSaveNoticeSeen(false);
+      }
+    } catch {
+      // Storage unreadable — stay hidden (safe, no flash).
+    }
+  }, []);
   useEffect(() => {
     if (connectivity === "online" && !saveNoticeSeen) {
       try {
@@ -181,73 +187,74 @@ export function MapPage() {
         placeMarkers={placeMarkers}
       />
 
-      {/* Offline notice: purely connectivity-driven (never tile-error
-          state), so it shows even when cached tiles render fine, hides on
-          reconnect, and never flickers per tile. */}
-      {isOffline && (
-        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur">
-          <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
-            <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
-          </div>
-        </div>
-      )}
-
-      {/* One-time save notice: informational only, online only, never
-          stacked with the offline banner. */}
-      {showSaveNotice && (
-        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
-          <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
-            <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
-          </div>
-          <button
-            type="button"
-            onClick={dismissSaveNotice}
-            aria-label={t.close}
-            className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+      {/* Top overlay stack: banner/notice/place cards lay out in normal
+          flow inside ONE absolute container, so variable card heights
+          (fa/en copy, font size, screen width) can never overlap. */}
+      <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md flex-col gap-1.5">
+        {/* Offline notice: purely connectivity-driven (never tile-error
+            state), so it shows even when cached tiles render fine, hides on
+            reconnect, and never flickers per tile. */}
+        {isOffline && (
+          <div
+            data-testid="map-offline-banner"
+            className="flex items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur"
           >
-            <X className="size-3.5" />
-          </button>
-        </div>
-      )}
+            <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
+              <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
+            </div>
+          </div>
+        )}
 
-      {visiblePlaceInfos.length > 0 && (
-        <div
-          className={cn(
-            "absolute inset-x-3 z-[500] mx-auto flex max-w-md flex-col gap-1.5",
-            isOffline ? "top-28" : "top-14",
-          )}
-        >
-          {visiblePlaceInfos.map((p) => (
-            <div
-              key={`${p.role}:${p.label}`}
-              className={cn(
-                "flex items-start gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm backdrop-blur",
-                p.tooFar
-                  ? "border-amber-500/40 bg-background/95 text-foreground"
-                  : "border-border bg-background/90 text-foreground",
-              )}
+        {/* One-time save notice: informational only, online only, never
+            stacked with the offline banner. */}
+        {showSaveNotice && (
+          <div className="flex items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
+            <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
+              <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
+            </div>
+            <button
+              type="button"
+              onClick={dismissSaveNotice}
+              aria-label={t.close}
+              className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
-              {p.tooFar ? (
-                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
-              ) : (
-                <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
-              )}
-              <div className="min-w-0 flex-1">
-                <p className="truncate font-medium">{p.label}</p>
-                <p className="mt-0.5 text-muted-foreground">
-                  {t.nearestStation}: {p.stationName} · {p.distanceText} · ~{p.walkText} {t.walkTime}
+              <X className="size-3.5" />
+            </button>
+          </div>
+        )}
+
+        {visiblePlaceInfos.map((p) => (
+          <div
+            key={`${p.role}:${p.label}`}
+            data-testid="map-place-card"
+            className={cn(
+              "flex items-start gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm backdrop-blur",
+              p.tooFar
+                ? "border-amber-500/40 bg-background/95 text-foreground"
+                : "border-border bg-background/90 text-foreground",
+            )}
+          >
+            {p.tooFar ? (
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+            ) : (
+              <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium">{p.label}</p>
+              <p className="mt-0.5 text-muted-foreground">
+                {t.nearestStation}: {p.stationName} · {p.distanceText} · ~{p.walkText} {t.walkTime}
+              </p>
+              {p.tooFar && (
+                <p className="mt-0.5 font-medium text-amber-600 dark:text-amber-400">
+                  {t.tooFarFromStation} (~{p.walkText})
                 </p>
-                {p.tooFar && (
-                  <p className="mt-0.5 font-medium text-amber-600 dark:text-amber-400">
-                    {t.tooFarFromStation} (~{p.walkText})
-                  </p>
-                )}
-              </div>
-              {ENABLE_PLACE_CARD_DISMISS && (
+              )}
+            </div>
+            {ENABLE_PLACE_CARD_DISMISS && (
               <button
                 type="button"
                 onClick={() =>
@@ -258,11 +265,10 @@ export function MapPage() {
               >
                 <X className="size-3.5" />
               </button>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+            )}
+          </div>
+        ))}
+      </div>
 
       {/* Map mode toggle */}
       <div className="absolute top-3 left-3 z-[500] flex overflow-hidden rounded-lg border border-border bg-background/90 shadow-sm backdrop-blur">

--- a/app/map/client.tsx
+++ b/app/map/client.tsx
@@ -109,11 +109,11 @@ export function MapPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(initialParams.station);
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(new Set());
-  // Shared connectivity state (mount + online/offline + pageshow +
-  // foreground resync), so the banner reflects real network state even
-  // after the PWA resumes from background — never tile-error state.
-  const online = useConnectivity();
-  const isOffline = !online;
+  // Effective connectivity (verified reachability, not just link state):
+  // the banner shows only on confirmed offline — never during checking,
+  // so a normal launch waiting ~ms for verification never flashes it.
+  const { state: connectivity } = useConnectivity();
+  const isOffline = connectivity === "offline";
 
   // One-time informational save notice: shown once per device while online,
   // remembered locally. Never stacked with the offline banner, never a
@@ -127,15 +127,16 @@ export function MapPage() {
   });
   const [saveNoticeDismissed, setSaveNoticeDismissed] = useState(false);
   useEffect(() => {
-    if (online && !saveNoticeSeen) {
+    if (connectivity === "online" && !saveNoticeSeen) {
       try {
         localStorage.setItem("metto.mapSaveNoticeSeen", "1");
       } catch {
         // Private mode etc. — notice simply shows again next visit.
       }
     }
-  }, [online, saveNoticeSeen]);
-  const showSaveNotice = online && !saveNoticeSeen && !saveNoticeDismissed;
+  }, [connectivity, saveNoticeSeen]);
+  const showSaveNotice =
+    connectivity === "online" && !saveNoticeSeen && !saveNoticeDismissed;
   function dismissSaveNotice() {
     setSaveNoticeDismissed(true);
     try {

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -17,6 +17,7 @@ import { OfflineStatus } from "@/components/offline-status";
 import { useMetro } from "./providers";
 import { STRINGS } from "@/lib/i18n";
 import { buildTabHref } from "@/lib/geo";
+import { isPrecachedTabUrl, shouldInterceptOfflineNav, useConnectivity } from "@/lib/offline/use-connectivity";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
@@ -26,10 +27,63 @@ const NAV_ITEMS = [
   { href: "/map", labelKey: "tabMap" as const, icon: MapIcon },
 ] as const;
 
+/**
+ * Top-level tab link. Online it behaves exactly like Next <Link> (client
+ * navigation + prefetch). Offline, plain primary clicks on the four
+ * precached static tabs use a native full-document navigation instead:
+ * client-side RSC fetches cannot succeed offline and would abort the
+ * transition, while a document request is served from the Serwist
+ * precache. Modifier/middle clicks, new-tab targets and non-precached
+ * URLs keep normal browser semantics.
+ */
+function TabLink({
+  href,
+  online,
+  className,
+  ariaCurrent,
+  children,
+}: {
+  href: string;
+  online: boolean;
+  className?: string;
+  ariaCurrent?: "page";
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-current={ariaCurrent}
+      onClick={(e) => {
+        if (online || e.defaultPrevented) return;
+        if (
+          !shouldInterceptOfflineNav({
+            button: e.button,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+            shiftKey: e.shiftKey,
+            altKey: e.altKey,
+            target: (e.currentTarget as HTMLAnchorElement).target,
+          })
+        ) {
+          return;
+        }
+        if (!isPrecachedTabUrl(href)) return;
+        e.preventDefault();
+        window.location.assign(href);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
 export function AppNav() {
   const { lang, setLang, originId, destId, originPlace, destPlace } = useMetro();
   const pathname = usePathname();
   const t = STRINGS[lang];
+  // One shared subscription for every tab link below.
+  const online = useConnectivity();
 
   const currentPath = pathname === "/" ? "/" : pathname;
   const isMainTab = currentPath === "/";
@@ -53,7 +107,7 @@ export function AppNav() {
   return (
     <>
       <header className="z-20 flex items-center justify-between gap-3 border-b border-border bg-card/80 px-4 py-3 backdrop-blur md:px-6 md:py-4">
-        <Link href="/" className="flex items-center gap-2.5 md:gap-3">
+          <TabLink href="/" online={online} className="flex items-center gap-2.5 md:gap-3">
           <span className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground md:size-10">
             <TrainFront className="size-5 md:size-6" />
           </span>
@@ -61,7 +115,7 @@ export function AppNav() {
             <h1 className="text-base font-bold md:text-lg">{t.appTitle}</h1>
             <p className="text-xs text-muted-foreground md:text-sm">{t.appSubtitle}</p>
           </div>
-        </Link>
+        </TabLink>
 
         {/* desktop tabs */}
         <nav className="hidden items-center gap-1 md:flex">
@@ -69,9 +123,10 @@ export function AppNav() {
             const href = getHref(item.href);
             const active = currentPath === item.href;
             return (
-              <Link
+              <TabLink
                 key={item.href}
                 href={href}
+                online={online}
                 className={cn(
                   "flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors md:gap-2 md:px-4 md:py-2.5 md:text-base",
                   active
@@ -81,7 +136,7 @@ export function AppNav() {
               >
                 <item.icon className="size-5" />
                 {t[item.labelKey]}
-              </Link>
+              </TabLink>
             );
           })}
         </nav>
@@ -142,18 +197,19 @@ export function AppNav() {
             const href = getHref(item.href);
             const active = currentPath === item.href;
             return (
-              <Link
+              <TabLink
                 key={item.href}
                 href={href}
+                online={online}
                 className={cn(
                   "flex flex-col items-center gap-1 py-2.5 text-xs font-medium transition-colors",
                   active ? "text-primary" : "text-muted-foreground",
                 )}
-                aria-current={active ? "page" : undefined}
+                ariaCurrent={active ? "page" : undefined}
               >
                 <item.icon className="size-5" />
                 {t[item.labelKey]}
-              </Link>
+              </TabLink>
             );
           })}
         </nav>

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -17,7 +17,12 @@ import { OfflineStatus } from "@/components/offline-status";
 import { useMetro } from "./providers";
 import { STRINGS } from "@/lib/i18n";
 import { buildTabHref } from "@/lib/geo";
-import { isPrecachedTabUrl, shouldInterceptOfflineNav, useConnectivity } from "@/lib/offline/use-connectivity";
+import {
+  isPrecachedTabUrl,
+  shouldInterceptOfflineNav,
+  useConnectivity,
+  type ConnectivityState,
+} from "@/lib/offline/use-connectivity";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
@@ -28,23 +33,32 @@ const NAV_ITEMS = [
 ] as const;
 
 /**
- * Top-level tab link. Online it behaves exactly like Next <Link> (client
- * navigation + prefetch). Offline, plain primary clicks on the four
- * precached static tabs use a native full-document navigation instead:
- * client-side RSC fetches cannot succeed offline and would abort the
- * transition, while a document request is served from the Serwist
- * precache. Modifier/middle clicks, new-tab targets and non-precached
- * URLs keep normal browser semantics.
+ * Top-level tab link. When effectively online it behaves exactly like Next
+ * <Link> (client navigation + prefetch). Otherwise (offline, or still
+ * checking — the safe default since destinations are precached), plain
+ * primary clicks on the four precached static tabs use a native
+ * full-document navigation instead: client-side RSC fetches cannot succeed
+ * offline and would abort the transition, while a document request is
+ * served from the Serwist precache. Modifier/middle clicks, new-tab targets
+ * and non-precached URLs keep normal browser semantics.
+ *
+ * Offline-ness is decided synchronously at event time from BOTH the shared
+ * connectivity state and the live `navigator.onLine` getter: React state
+ * can lag a just-fired offline event by a frame, and a tap landing in that
+ * window must still take the safe path (a failed client navigation leaves
+ * a broken intermediate tree). Bias is deliberate — full-document
+ * navigation works online too for precached tabs, while a client
+ * navigation while offline always breaks.
  */
 function TabLink({
   href,
-  online,
+  connectivity,
   className,
   ariaCurrent,
   children,
 }: {
   href: string;
-  online: boolean;
+  connectivity: ConnectivityState;
   className?: string;
   ariaCurrent?: "page";
   children: React.ReactNode;
@@ -55,7 +69,7 @@ function TabLink({
       className={className}
       aria-current={ariaCurrent}
       onClick={(e) => {
-        if (online || e.defaultPrevented) return;
+        if (e.defaultPrevented) return;
         if (
           !shouldInterceptOfflineNav({
             button: e.button,
@@ -69,6 +83,16 @@ function TabLink({
           return;
         }
         if (!isPrecachedTabUrl(href)) return;
+        const stateOffline = connectivity !== "online";
+        let linkOffline = false;
+        try {
+          linkOffline =
+            typeof navigator !== "undefined" && navigator.onLine === false;
+        } catch {
+          linkOffline = false;
+        }
+        // Normal Next behavior only when BOTH agree we are online.
+        if (!stateOffline && !linkOffline) return;
         e.preventDefault();
         window.location.assign(href);
       }}
@@ -83,7 +107,7 @@ export function AppNav() {
   const pathname = usePathname();
   const t = STRINGS[lang];
   // One shared subscription for every tab link below.
-  const online = useConnectivity();
+  const { state: connectivity } = useConnectivity();
 
   const currentPath = pathname === "/" ? "/" : pathname;
   const isMainTab = currentPath === "/";
@@ -107,7 +131,7 @@ export function AppNav() {
   return (
     <>
       <header className="z-20 flex items-center justify-between gap-3 border-b border-border bg-card/80 px-4 py-3 backdrop-blur md:px-6 md:py-4">
-          <TabLink href="/" online={online} className="flex items-center gap-2.5 md:gap-3">
+          <TabLink href="/" connectivity={connectivity} className="flex items-center gap-2.5 md:gap-3">
           <span className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground md:size-10">
             <TrainFront className="size-5 md:size-6" />
           </span>
@@ -126,7 +150,7 @@ export function AppNav() {
               <TabLink
                 key={item.href}
                 href={href}
-                online={online}
+                connectivity={connectivity}
                 className={cn(
                   "flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors md:gap-2 md:px-4 md:py-2.5 md:text-base",
                   active
@@ -200,7 +224,7 @@ export function AppNav() {
               <TabLink
                 key={item.href}
                 href={href}
-                online={online}
+                connectivity={connectivity}
                 className={cn(
                   "flex flex-col items-center gap-1 py-2.5 text-xs font-medium transition-colors",
                   active ? "text-primary" : "text-muted-foreground",

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -9,7 +9,8 @@
 // Conservative runtime policy:
 // - precache: app shell + build assets + local JSON/icons (versioned)
 // - CacheFirst: immutable same-origin /_next/static
-// - NetworkFirst (+ offline fallback to "/"): same-origin navigations/RSC
+// - NetworkFirst (+ pathname-aware offline document fallback): same-origin
+//   navigations/RSC — a failed `/map?...` serves precached `/map`, never `/`
 // - NetworkFirst: /holidays.version.json update pointer (not precached)
 // - NetworkOnly: same-origin /api/* and version-pinned dataset downloads
 // - Cross-origin: NO blanket route — unmatched requests (Nominatim,
@@ -34,6 +35,10 @@ import {
   isCacheableTileResponse,
   isCartoTileRequest,
 } from "../lib/map/carto-tiles";
+import {
+  CANONICAL_STATIC_DOCS,
+  canonicalDocFallbackFor,
+} from "../lib/offline/document-fallback";
 
 declare global {
   interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -186,7 +191,10 @@ const serwist = new Serwist({
     },
     {
       // Same-origin navigations + App Router RSC. NetworkFirst keeps
-      // deployments fresh; the precached "/" fallback renders offline.
+      // deployments fresh. Offline, failed navigations resolve through the
+      // pathname-aware fallback entries below (canonical precached
+      // document per tab); RSC failures propagate untouched — HTML is
+      // never served as a fake RSC response.
       // Only 200 basic HTML/RSC responses are stored (no errors, no
       // redirects — those would poison the cache across deploys).
       matcher: ({ request, sameOrigin, url }) => {
@@ -220,14 +228,25 @@ const serwist = new Serwist({
     },
   ],
   fallbacks: {
-    entries: [
-      {
-        url: "/",
-        matcher({ request }) {
-          return request.destination === "document";
-        },
-      },
-    ],
+    // Pathname-aware offline documents: a failed navigation to e.g.
+    // `/map?from=ahang&to=aliabad` resolves to the precached canonical
+    // `/map` document (query ignored ONLY for the cache lookup — the
+    // browser URL is never touched). Never `/` for other pages, never a
+    // fallback for unknown routes, and never HTML for RSC (non-navigate
+    // requests match no entry and fail normally).
+    entries: CANONICAL_STATIC_DOCS.map((pathname) => ({
+      url: pathname,
+      matcher: ({ request }: { request: Request }) =>
+        canonicalDocFallbackFor(
+          pathname as `/${string}`,
+          {
+            mode: request.mode,
+            destination: (request as Request).destination,
+            url: request.url,
+            origin: self.location.origin,
+          },
+        ) !== null,
+    })),
   },
 });
 

--- a/components/offline-status.tsx
+++ b/components/offline-status.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CheckCircle2, WifiOff, X } from "lucide-react";
 import { useOfflineReadiness } from "@/lib/offline/use-offline-readiness";
+import { useConnectivity } from "@/lib/offline/use-connectivity";
 import { useHolidayData } from "@/lib/holidays/use-holiday-data";
 import { ensurePersistentStorage } from "@/lib/offline/storage";
 import { scheduleRegistrationDiagnostic } from "@/lib/offline/sw-registration-diagnostic";
@@ -50,13 +51,38 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
     holidayLoaded,
     precacheReady,
   } = readiness;
+  // Shared effective state (same singleton every consumer observes).
+  const {
+    state: connectivity,
+    navigatorOnline,
+    reachabilityVerified,
+  } = useConnectivity();
+
+  // Anti-flicker grace (≈1.75 s) for the GLOBAL warning only: internal
+  // connectivity transitions immediately, but the warning appears only if
+  // still offline-incomplete after the grace. Recovery inside the window
+  // means it never renders.
+  const [warningArmed, setWarningArmed] = useState(false);
+  useEffect(() => {
+    if (phase !== "offline-incomplete") {
+      setWarningArmed(false);
+      return;
+    }
+    const timer = window.setTimeout(() => setWarningArmed(true), 1750);
+    return () => window.clearTimeout(timer);
+  }, [phase]);
 
   // Debug-only transition log: fires only when a meaningful value changes,
-  // never on every render.
+  // never on every render. Distinguishes link state (navigatorOnline)
+  // from effective reachability (connectivity) — the VPN case reads
+  // navigatorOnline: true with connectivity: "offline".
   const lastLoggedRef = useRef<string>("");
   useEffect(() => {
     const snapshot = {
       state: phase,
+      connectivity,
+      navigatorOnline,
+      reachabilityVerified,
       serviceWorkerControlled: swControlling,
       precacheReady,
       scheduleReady: scheduleLoaded,
@@ -72,7 +98,7 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
     } catch {
       // Diagnostics must never break the app.
     }
-  }, [phase, swControlling, precacheReady, scheduleLoaded, holidayLoaded, online]);
+  }, [phase, connectivity, navigatorOnline, reachabilityVerified, swControlling, precacheReady, scheduleLoaded, holidayLoaded, online]);
 
   return (
     <div
@@ -81,7 +107,7 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
       data-phase={phase}
       className="z-10 flex flex-col items-stretch gap-1 px-4 pt-1 md:px-6"
     >
-      {phase === "offline-incomplete" && (
+      {phase === "offline-incomplete" && warningArmed && (
         <StatusRow tone="warn">
           <WifiOff className="size-3.5 shrink-0" />
           <span className="min-w-0 flex-1">

--- a/components/offline-status.tsx
+++ b/components/offline-status.tsx
@@ -50,6 +50,8 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
     scheduleLoaded,
     holidayLoaded,
     precacheReady,
+    coreReady,
+    readinessVerified,
   } = readiness;
   // Shared effective state (same singleton every consumer observes).
   const {
@@ -75,7 +77,10 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
   // Debug-only transition log: fires only when a meaningful value changes,
   // never on every render. Distinguishes link state (navigatorOnline)
   // from effective reachability (connectivity) — the VPN case reads
-  // navigatorOnline: true with connectivity: "offline".
+  // navigatorOnline: true with connectivity: "offline". readinessVerified
+  // + coreReady expose the UNKNOWN-vs-MISSING gate: offline boot must show
+  // {readinessVerified: false, coreReady: false, phase: "preparing"} and
+  // transition straight to offline-ready with no offline-incomplete between.
   const lastLoggedRef = useRef<string>("");
   useEffect(() => {
     const snapshot = {
@@ -83,6 +88,8 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
       connectivity,
       navigatorOnline,
       reachabilityVerified,
+      readinessVerified,
+      coreReady,
       serviceWorkerControlled: swControlling,
       precacheReady,
       scheduleReady: scheduleLoaded,
@@ -98,7 +105,7 @@ export function OfflineStatus({ lang }: { lang: Lang }) {
     } catch {
       // Diagnostics must never break the app.
     }
-  }, [phase, connectivity, navigatorOnline, reachabilityVerified, swControlling, precacheReady, scheduleLoaded, holidayLoaded, online]);
+  }, [phase, connectivity, navigatorOnline, reachabilityVerified, readinessVerified, coreReady, swControlling, precacheReady, scheduleLoaded, holidayLoaded, online]);
 
   return (
     <div

--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -21,7 +21,7 @@ import {
 import type { MetroStation } from "@/lib/metro/types";
 import { STATION_MAP, type RouteResult } from "@/lib/route"
 import { type Lang } from "@/lib/i18n"
-import { useConnectivity } from "@/lib/offline/use-connectivity"
+import { useConnectivity, type ConnectivityState } from "@/lib/offline/use-connectivity"
 import { cn } from "@/lib/utils"
 
 type Props = {
@@ -152,10 +152,13 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
   const [locating, setLocating] = useState(false)
   const [gpsError, setGpsError] = useState<string | null>(null)
   const isFa = lang === "fa"
-  const online = useConnectivity()
-  // Tracks the previous connectivity value so only a real offline → online
-  // transition triggers a retry — an initial online mount is not one.
-  const wasOnlineRef = useRef(online)
+  const { state: connectivity } = useConnectivity()
+  // Tracks the previous EFFECTIVE connectivity state so only a real
+  // offline → online transition triggers a retry. In particular,
+  // checking → online (e.g. after a pageshow resync while already online)
+  // must not redraw: nothing failed, so there is nothing to retry.
+  // An initial online mount is likewise not a transition.
+  const prevConnectivityRef = useRef<ConnectivityState>(connectivity)
 
   const edges = useMemo(() => buildMapEdges(), [])
   const routeStations = useMemo(() => new Set(route?.path ?? []), [route])
@@ -472,21 +475,21 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
     }
   }, [mapMode])
 
-  // Retry the active basemap layer(s) when connectivity returns, so tiles
-  // that failed while offline start loading without any zoom/pan gesture.
-  // Runs only on a real offline → online transition: the effect fires when
-  // the boolean flips, and repeated `online` events while already online
-  // change no state. No remount, no view reset, no overlay or cache touch.
+  // Retry the active basemap layer(s) when EFFECTIVE connectivity returns,
+  // so tiles that failed while offline start loading without any zoom/pan
+  // gesture. Runs only on a real offline → online transition of the shared
+  // state (checking → online is not one). No remount, no view reset, no
+  // overlay or cache touch.
   useEffect(() => {
-    const wasOnline = wasOnlineRef.current
-    wasOnlineRef.current = online
-    if (!online || wasOnline) return
+    const was = prevConnectivityRef.current
+    prevConnectivityRef.current = connectivity
+    if (was !== "offline" || connectivity !== "online") return
     const map = mapRef.current
     if (!map) return
     for (const layer of [tileLayerRef.current, minimalistLayerRef.current, labelsLayerRef.current]) {
       if (layer && map.hasLayer(layer)) layer.redraw()
     }
-  }, [online])
+  }, [connectivity])
 
   // Redraw overlay whenever the route/selection changes.
   useEffect(() => {

--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -21,6 +21,7 @@ import {
 import type { MetroStation } from "@/lib/metro/types";
 import { STATION_MAP, type RouteResult } from "@/lib/route"
 import { type Lang } from "@/lib/i18n"
+import { useConnectivity } from "@/lib/offline/use-connectivity"
 import { cn } from "@/lib/utils"
 
 type Props = {
@@ -151,6 +152,10 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
   const [locating, setLocating] = useState(false)
   const [gpsError, setGpsError] = useState<string | null>(null)
   const isFa = lang === "fa"
+  const online = useConnectivity()
+  // Tracks the previous connectivity value so only a real offline → online
+  // transition triggers a retry — an initial online mount is not one.
+  const wasOnlineRef = useRef(online)
 
   const edges = useMemo(() => buildMapEdges(), [])
   const routeStations = useMemo(() => new Set(route?.path ?? []), [route])
@@ -466,6 +471,22 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
       container.style.backgroundColor = ""
     }
   }, [mapMode])
+
+  // Retry the active basemap layer(s) when connectivity returns, so tiles
+  // that failed while offline start loading without any zoom/pan gesture.
+  // Runs only on a real offline → online transition: the effect fires when
+  // the boolean flips, and repeated `online` events while already online
+  // change no state. No remount, no view reset, no overlay or cache touch.
+  useEffect(() => {
+    const wasOnline = wasOnlineRef.current
+    wasOnlineRef.current = online
+    if (!online || wasOnline) return
+    const map = mapRef.current
+    if (!map) return
+    for (const layer of [tileLayerRef.current, minimalistLayerRef.current, labelsLayerRef.current]) {
+      if (layer && map.hasLayer(layer)) layer.redraw()
+    }
+  }, [online])
 
   // Redraw overlay whenever the route/selection changes.
   useEffect(() => {

--- a/docs/TWA_READINESS.md
+++ b/docs/TWA_READINESS.md
@@ -126,9 +126,10 @@ hang, never a misleading empty state):
   file list exists. Current production precache: 46 URLs (~8.4 MB).
 - **Runtime rules** (`app/sw.ts`, conservative by design):
   - `CacheFirst`: immutable same-origin `/_next/static/*`.
-  - `NetworkFirst`: same-origin navigations/RSC (8 s timeout) with an
-    offline fallback to precached `/`; only `200` basic responses stored
-    (errors/redirects can never poison the cache across deploys).
+  - `NetworkFirst`: same-origin navigations/RSC (8 s timeout) with
+    pathname-aware offline document fallback (see below); only `200`
+    basic responses stored (errors/redirects can never poison the cache
+    across deploys).
   - `NetworkFirst`: `/holidays.version.json` (tiny update pointer,
     deliberately **not** precached so it revalidates).
   - `NetworkOnly` (never cached): `POST` (no rule matches non-GET),
@@ -138,6 +139,14 @@ hang, never a misleading empty state):
     except the narrow opportunistic CARTO tile rule (§2.1).
 - **Installation:** the worker precaches during `install`; activation
   removes legacy `metto-v*` caches from the old hand-written worker.
+- **Offline document fallback (pathname-aware):** tab links preserve
+  route state as query params (`/map?from=…&to=…`), and Serwist only
+  strips `utm_*`/`fbclid` when matching precache — so a query-bearing
+  navigation can never hit the canonical entry directly. On failure the
+  worker therefore resolves each of `/`, `/map`, `/stations`, `/nearby`
+  to its own precached HTML (query ignored for lookup only; the address
+  bar is untouched). There is deliberately **no** universal `/` fallback
+  and no fallback for unknown paths, and HTML is never served for RSC.
 - **Updating (silent by design):** a new worker **never** `skipWaiting()`
   on its own (`skipWaiting: false`), the app shows **no** update banner,
   toast, or dialog, and a running session is **never** reloaded for an

--- a/docs/TWA_READINESS.md
+++ b/docs/TWA_READINESS.md
@@ -310,6 +310,32 @@ restore network
 verify recovery + update banner behavior if a deploy happened
 ```
 
+Map reconnect + offline tabs (also on real Android Chrome / installed PWA):
+
+```text
+install/open Metto online
+↓
+open Map (note the one-time save notice on first visit)
+↓
+go offline
+↓
+pan into an uncached area (blank tiles, offline banner "بدون اینترنت")
+↓
+put the PWA in background
+↓
+restore Internet
+↓
+reopen the PWA (no zoom/pan)
+↓
+missing visible tiles begin loading on their own; banner clears
+↓
+toggle offline again
+↓
+tap Route/Map/Stations/Nearby repeatedly (from /?from=…&to=… too)
+↓
+every static tab opens offline with route state intact
+```
+
 Automated equivalent: `pnpm build && pnpm test:e2e:offline`
 (Playwright, production server, real browser offline mode, mocked Tehran
 geolocation `35.6892, 51.3890`; Nominatim/CARTO/Esri/upstream-holiday

--- a/docs/TWA_READINESS.md
+++ b/docs/TWA_READINESS.md
@@ -48,6 +48,27 @@ are logged as `console.debug("[Metto Offline]", …)` and mirrored to
 3. The timetable dataset is loaded in memory.
 4. The holiday dataset is loaded in memory.
 
+### Effective connectivity (not just `navigator.onLine`)
+
+`navigator.onLine` only reflects link state: with Wi-Fi/cellular off but an
+Android VPN virtual interface up, it stays `true` with no usable Internet.
+Metto therefore tracks *effective* reachability (`lib/offline/`):
+
+- States: `checking` → `online` (only after `GET /api/connectivity`
+  returns 204) or `offline` (link down, or probe failed/timed out at ~3 s).
+- `/api/connectivity` is a bodyless 204 with `Cache-Control: no-store`
+  and the SW keeps `/api/*` `NetworkOnly`, so a success always proves a
+  live round trip — never a cache hit.
+- One shared singleton store (module-level + `useSyncExternalStore`):
+  one listener set, one in-flight probe, one retry timer per page; all of
+  OfflineStatus, map banner, `RealMap` redraw, and `TabLink` observe it.
+- Resync on mount, `online`/`offline` events, `pageshow`, and foreground
+  `visibilitychange`. A visible-only ~25 s retry covers recovery with no
+  browser event (VPN case); nothing polls while hidden or link-down.
+- UI matrix: `checking` shows no offline UI anywhere (but tab taps already
+  take the safe document path); the global warning appears only for
+  confirmed-offline + missing core after a ~1.75 s anti-flicker grace.
+
 ---
 
 ## 2. Internet-required functionality
@@ -343,6 +364,29 @@ toggle offline again
 tap Route/Map/Stations/Nearby repeatedly (from /?from=…&to=… too)
 ↓
 every static tab opens offline with route state intact
+```
+
+VPN false-online case (real Android, installed PWA):
+
+```text
+open installed Metto PWA online, confirm ready
+↓
+leave VPN connected; turn Wi-Fi OFF and cellular data OFF
+↓
+wait for reachability verification (no browser event needed)
+↓
+Metto shows the normal offline state even if the OS still claims online
+↓
+cycle Route → Map → Stations → Nearby → Route (all precached tabs work)
+↓
+turn Wi-Fi back ON (VPN still enabled)
+↓
+offline banner disappears; missing map imagery resumes without zoom/pan;
+no full-page refresh
+↓
+background the PWA, change connectivity, resume it
+↓
+state reflects current effective connectivity, not pre-suspend state
 ```
 
 Automated equivalent: `pnpm build && pnpm test:e2e:offline`

--- a/i18n.test.ts
+++ b/i18n.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { persianDigits } from "./lib/i18n";
+import { persianDigits, STRINGS } from "./lib/i18n";
 
 describe("persianDigits locale behavior", () => {
   it('converts Latin digits to Persian in fa UI ("15:11" -> "۱۵:۱۱")', () => {
@@ -8,5 +8,18 @@ describe("persianDigits locale behavior", () => {
 
   it('keeps Latin digits in en UI ("15:11" stays "15:11")', () => {
     expect(persianDigits("15:11", "en")).toBe("15:11");
+  });
+});
+
+describe("map offline/save notice copy", () => {
+  it("exists in both languages with the exact approved wording", () => {
+    expect(STRINGS.fa.mapOfflineTitle).toBe("بدون اینترنت");
+    expect(STRINGS.en.mapOfflineTitle).toBe("You're offline");
+    expect(STRINGS.fa.mapOfflineBody).toContain("قبلاً دیده‌اید");
+    expect(STRINGS.en.mapOfflineBody).toContain("viewed before");
+    expect(STRINGS.fa.mapSaveTitle).toBe("ذخیره برای استفاده آفلاین");
+    expect(STRINGS.en.mapSaveTitle).toBe("Saved for offline use");
+    expect(STRINGS.fa.mapSaveBody).not.toMatch(/کش|tile/i);
+    expect(STRINGS.en.mapSaveBody).not.toMatch(/cache|tile|service worker/i);
   });
 });

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -79,8 +79,12 @@ export const STRINGS = {
     placeSearchOffline: "Internet is required to search for places.",
     offlineNotPrepared:
       "Offline data hasn't finished downloading on this device. Connect to the Internet once to prepare Metto for offline use.",
-    mapOfflineNote:
-      "The basemap requires Internet; metro lines and stations are still available offline.",
+    mapOfflineTitle: "You're offline",
+    mapOfflineBody:
+      "Areas you've viewed before may still be available. Connect to the internet to load new areas of the map.",
+    mapSaveTitle: "Saved for offline use",
+    mapSaveBody:
+      "Areas of the map you view are saved for use without an internet connection. The entire map is not available offline.",
     holidaysTitle: "Official holidays",
     holidayLastUpdate: "Last update",
     upcomingHolidays: "Upcoming holidays",
@@ -194,8 +198,12 @@ export const STRINGS = {
     placeSearchOffline: "برای جستجوی مکان به اینترنت نیاز است.",
     offlineNotPrepared:
       "این دستگاه هنوز برای استفاده آفلاین آماده نشده است. برای دریافت اطلاعات لازم یک‌بار به اینترنت متصل شوید.",
-    mapOfflineNote:
-      "نقشه پایه به اینترنت نیاز دارد؛ خطوط و ایستگاه‌های مترو آفلاین نمایش داده می‌شوند.",
+    mapOfflineTitle: "بدون اینترنت",
+    mapOfflineBody:
+      "بخش‌هایی از نقشه که قبلاً دیده‌اید همچنان در دسترس‌اند. برای دیدن بخش‌های جدید نقشه به اینترنت نیاز دارید.",
+    mapSaveTitle: "ذخیره برای استفاده آفلاین",
+    mapSaveBody:
+      "بخش‌هایی از نقشه که می‌بینید، برای استفاده بدون اینترنت ذخیره می‌شوند. همهٔ نقشه آفلاین نیست.",
     holidaysTitle: "تعطیلات رسمی",
     holidayLastUpdate: "آخرین بروزرسانی",
     upcomingHolidays: "تعطیلات پیش‌رو",

--- a/lib/offline/connectivity-machine.test.ts
+++ b/lib/offline/connectivity-machine.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createConnectivityMachine,
+  type ConnectivityMachine,
+  type ConnectivitySnapshot,
+} from "./connectivity-machine";
+
+interface Harness {
+  machine: ConnectivityMachine;
+  snapshots: ConnectivitySnapshot[];
+  setNavigatorOnline: (v: boolean) => void;
+  setVisible: (v: boolean) => void;
+  resolveProbe: (index: number, ok: boolean) => Promise<void>;
+  rejectProbe: (index: number, err?: unknown) => Promise<void>;
+  probeCalls: number;
+}
+
+function createHarness(opts?: {
+  probeTimeoutMs?: number;
+  retryIntervalMs?: number;
+}): Harness {
+  let navigatorOnline = true;
+  let visible = true;
+  const pending: Array<{
+    resolve: (ok: boolean) => void;
+    reject: (err: unknown) => void;
+  }> = [];
+  const snapshots: ConnectivitySnapshot[] = [];
+  let probeCalls = 0;
+  const machine = createConnectivityMachine({
+    getNavigatorOnline: () => navigatorOnline,
+    isDocumentVisible: () => visible,
+    probe: () =>
+      new Promise<boolean>((resolve, reject) => {
+        probeCalls += 1;
+        pending.push({ resolve, reject });
+      }),
+    probeTimeoutMs: opts?.probeTimeoutMs,
+    retryIntervalMs: opts?.retryIntervalMs,
+    onChange: (s) => snapshots.push(s),
+  });
+  const flush = () => vi.advanceTimersByTimeAsync(0);
+  return {
+    machine,
+    snapshots,
+    setNavigatorOnline: (v: boolean) => {
+      navigatorOnline = v;
+    },
+    setVisible: (v: boolean) => {
+      visible = v;
+    },
+    resolveProbe: async (index: number, ok: boolean) => {
+      pending[index].resolve(ok);
+      await flush();
+    },
+    rejectProbe: async (index: number, err: unknown = new Error("down")) => {
+      pending[index].reject(err);
+      await flush();
+    },
+    get probeCalls() {
+      return probeCalls;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("normal online", () => {
+  it("checking → probe 204 → online, exactly one probe", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    expect(h.machine.getSnapshot().state).toBe("checking");
+    expect(h.probeCalls).toBe(1);
+    await h.resolveProbe(0, true);
+    const s = h.machine.getSnapshot();
+    expect(s.state).toBe("online");
+    expect(s.reachabilityVerified).toBe(true);
+    expect(s.navigatorOnline).toBe(true);
+    h.machine.dispose();
+  });
+});
+
+describe("definite browser offline", () => {
+  it("goes offline immediately with no probe", async () => {
+    const h = createHarness();
+    h.setNavigatorOnline(false);
+    h.machine.handleMount();
+    const s = h.machine.getSnapshot();
+    expect(s.state).toBe("offline");
+    expect(s.reachabilityVerified).toBe(false);
+    expect(h.probeCalls).toBe(0);
+    h.machine.dispose();
+  });
+});
+
+describe("VPN-style false positive", () => {
+  it("navigator.onLine true + rejecting probe → offline, verified", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    await h.rejectProbe(0);
+    const s = h.machine.getSnapshot();
+    expect(s.state).toBe("offline");
+    expect(s.navigatorOnline).toBe(true);
+    expect(s.reachabilityVerified).toBe(true);
+    h.machine.dispose();
+  });
+});
+
+describe("timeout", () => {
+  it("probe exceeding the timeout → offline", async () => {
+    const h = createHarness({ probeTimeoutMs: 3000 });
+    h.machine.handleMount();
+    expect(h.machine.getSnapshot().state).toBe("checking");
+    await vi.advanceTimersByTimeAsync(3000);
+    const s = h.machine.getSnapshot();
+    expect(s.state).toBe("offline");
+    expect(s.reachabilityVerified).toBe(true);
+    h.machine.dispose();
+  });
+});
+
+describe("recovery", () => {
+  it("offline + link + succeeding probe → online", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    await h.rejectProbe(0);
+    expect(h.machine.getSnapshot().state).toBe("offline");
+    h.machine.handleOnlineEvent();
+    expect(h.machine.getSnapshot().state).toBe("checking");
+    await h.resolveProbe(1, true);
+    expect(h.machine.getSnapshot().state).toBe("online");
+    h.machine.dispose();
+  });
+
+  it("browser online event never jumps straight to online", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    await h.rejectProbe(0);
+    h.machine.handleOnlineEvent();
+    // Still checking until the probe resolves — never blindly online.
+    expect(h.machine.getSnapshot().state).toBe("checking");
+    h.machine.dispose();
+  });
+});
+
+describe("stale request protection", () => {
+  it("late failure of a superseded probe cannot overwrite online", async () => {
+    const h = createHarness();
+    h.machine.handleMount(); // probe 0
+    h.machine.handleResync(); // probe 1 supersedes probe 0
+    expect(h.probeCalls).toBe(2);
+    await h.resolveProbe(1, true);
+    expect(h.machine.getSnapshot().state).toBe("online");
+    await h.rejectProbe(0);
+    expect(h.machine.getSnapshot().state).toBe("online");
+    h.machine.dispose();
+  });
+
+  it("late success of a superseded probe cannot revive online", async () => {
+    const h = createHarness();
+    h.machine.handleMount(); // probe 0
+    h.machine.handleOfflineEvent(); // invalidates probe 0 → offline
+    expect(h.machine.getSnapshot().state).toBe("offline");
+    await h.resolveProbe(0, true);
+    expect(h.machine.getSnapshot().state).toBe("offline");
+    h.machine.dispose();
+  });
+});
+
+describe("event discipline", () => {
+  it("online event while already online issues no new probe", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    await h.resolveProbe(0, true);
+    expect(h.probeCalls).toBe(1);
+    h.machine.handleOnlineEvent();
+    expect(h.probeCalls).toBe(1);
+    h.machine.dispose();
+  });
+
+  it("offline event aborts the in-flight probe", async () => {
+    const h = createHarness();
+    h.machine.handleMount();
+    h.machine.handleOfflineEvent();
+    expect(h.machine.getSnapshot().state).toBe("offline");
+    // Late settle of the aborted probe changes nothing.
+    await h.resolveProbe(0, true);
+    expect(h.machine.getSnapshot().state).toBe("offline");
+    h.machine.dispose();
+  });
+});
+
+describe("visible-only retry", () => {
+  it("retries while offline-with-link and visible; stops when hidden", async () => {
+    const h = createHarness({ retryIntervalMs: 25000 });
+    h.machine.handleMount();
+    await h.rejectProbe(0);
+    expect(h.probeCalls).toBe(1);
+    await vi.advanceTimersByTimeAsync(25000);
+    expect(h.probeCalls).toBe(2);
+    // Hidden document: no further retries scheduled.
+    h.setVisible(false);
+    await vi.advanceTimersByTimeAsync(100000);
+    expect(h.probeCalls).toBe(2);
+    h.machine.dispose();
+  });
+
+  it("no retry while navigator.onLine is false", async () => {
+    const h = createHarness({ retryIntervalMs: 25000 });
+    h.setNavigatorOnline(false);
+    h.machine.handleMount();
+    await vi.advanceTimersByTimeAsync(100000);
+    expect(h.probeCalls).toBe(0);
+    h.machine.dispose();
+  });
+
+  it("retry success transitions to online", async () => {
+    const h = createHarness({ retryIntervalMs: 25000 });
+    h.machine.handleMount();
+    await h.rejectProbe(0);
+    await vi.advanceTimersByTimeAsync(25000);
+    expect(h.probeCalls).toBe(2);
+    await h.resolveProbe(1, true);
+    expect(h.machine.getSnapshot().state).toBe("online");
+    // And the cadence stops once online.
+    await vi.advanceTimersByTimeAsync(100000);
+    expect(h.probeCalls).toBe(2);
+    h.machine.dispose();
+  });
+});

--- a/lib/offline/connectivity-machine.ts
+++ b/lib/offline/connectivity-machine.ts
@@ -1,0 +1,306 @@
+// Effective-connectivity state machine (framework-free, fully testable).
+//
+// `navigator.onLine` only reflects link state (useless with e.g. an Android
+// VPN virtual interface up but Wi-Fi/cellular off), so usable Internet is
+// verified with a network-only probe (`GET /api/connectivity` → 204).
+//
+// States:
+// - "checking": the browser may have connectivity, but usable Internet has
+//   not been verified yet. Consumers must NOT show offline UI here, but
+//   navigation should already take the safe (precached-document) path.
+// - "online": the probe succeeded (204).
+// - "offline": the browser reports no link, or a probe verified
+//   unreachability.
+//
+// Stale-result protection: every probe run takes a monotonically increasing
+// generation ID, consumed by the first settle; later settles for the same
+// generation (timeout abort racing a late resolve/reject) are ignored, as
+// are settles from superseded generations. At most one probe and one retry
+// timer exist at any time.
+
+export type ConnectivityState = "checking" | "online" | "offline";
+
+export interface ConnectivitySnapshot {
+  state: ConnectivityState;
+  /** Raw `navigator.onLine` value last observed (link state, not truth). */
+  navigatorOnline: boolean;
+  /**
+   * True once a probe resolved for the current episode (success or
+   * failure). False when offline was entered via `navigator.onLine`
+   * alone, or while still checking.
+   */
+  reachabilityVerified: boolean;
+}
+
+/** Resolves true only for verified reachability (HTTP 204). */
+export type ConnectivityProbe = (signal: AbortSignal) => Promise<boolean>;
+
+export interface ConnectivityMachineDeps {
+  getNavigatorOnline: () => boolean;
+  isDocumentVisible: () => boolean;
+  probe: ConnectivityProbe;
+  /** Hard per-probe timeout. Default 3000 ms. */
+  probeTimeoutMs?: number;
+  /** Visible-only retry cadence while offline-with-link. Default 25000 ms. */
+  retryIntervalMs?: number;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  onChange: (snapshot: ConnectivitySnapshot) => void;
+}
+
+export interface ConnectivityMachine {
+  getSnapshot: () => ConnectivitySnapshot;
+  /** Initial mount. Probes unless the browser already reports offline. */
+  handleMount: () => void;
+  /** Browser `online` event: re-verify, never trust blindly. */
+  handleOnlineEvent: () => void;
+  /** Browser `offline` event: strong signal, abort anything in flight. */
+  handleOfflineEvent: () => void;
+  /** pageshow / foreground resync. */
+  handleResync: () => void;
+  dispose: () => void;
+}
+
+export function createConnectivityMachine(
+  deps: ConnectivityMachineDeps,
+): ConnectivityMachine {
+  const probeTimeoutMs = deps.probeTimeoutMs ?? 3000;
+  const retryIntervalMs = deps.retryIntervalMs ?? 25000;
+  // Looked up lazily so injected/fake clocks apply.
+  const schedule =
+    (...args: Parameters<typeof setTimeout>): ReturnType<typeof setTimeout> =>
+      (deps.setTimeoutFn ?? setTimeout)(...args);
+  const clearTimer = (id: ReturnType<typeof setTimeout>): void =>
+    (deps.clearTimeoutFn ?? clearTimeout)(id);
+
+  let disposed = false;
+  let generation = 0;
+  let probeController: AbortController | null = null;
+  let probeTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let snapshot: ConnectivitySnapshot = {
+    state: "checking",
+    navigatorOnline: true,
+    reachabilityVerified: false,
+  };
+
+  function emit(next: ConnectivitySnapshot): void {
+    snapshot = next;
+    deps.onChange(next);
+  }
+
+  function readLink(): boolean {
+    try {
+      return deps.getNavigatorOnline();
+    } catch {
+      return snapshot.navigatorOnline;
+    }
+  }
+
+  function clearProbeTimer(): void {
+    if (probeTimer !== null) {
+      clearTimer(probeTimer);
+      probeTimer = null;
+    }
+  }
+
+  function clearRetryTimer(): void {
+    if (retryTimer !== null) {
+      clearTimer(retryTimer);
+      retryTimer = null;
+    }
+  }
+
+  /** Abort the in-flight probe and invalidate its generation. */
+  function invalidateProbe(): void {
+    generation += 1;
+    clearProbeTimer();
+    if (probeController) {
+      try {
+        probeController.abort();
+      } catch {
+        // Ignore abort errors.
+      }
+      probeController = null;
+    }
+  }
+
+  function enterOffline(reachabilityVerified: boolean): void {
+    invalidateProbe();
+    emit({
+      state: "offline",
+      navigatorOnline: readLink(),
+      reachabilityVerified,
+    });
+    scheduleRetryIfNeeded();
+  }
+
+  function enterOnline(): void {
+    invalidateProbe();
+    emit({ state: "online", navigatorOnline: readLink(), reachabilityVerified: true });
+    scheduleRetryIfNeeded();
+  }
+
+  function enterChecking(): void {
+    emit({
+      state: "checking",
+      navigatorOnline: readLink(),
+      reachabilityVerified: false,
+    });
+  }
+
+  /**
+   * Conservative visible-only retry: while offline WITH a link and visible,
+   * periodically re-probe so recovery without a browser `online` event
+   * (VPN case) is eventually detected. State stays "offline" during the
+   * background probe — no UI flicker; only success transitions.
+   */
+  function scheduleRetryIfNeeded(): void {
+    clearRetryTimer();
+    if (disposed) return;
+    if (snapshot.state !== "offline") return;
+    let link = false;
+    let visible = false;
+    try {
+      link = deps.getNavigatorOnline();
+    } catch {
+      return;
+    }
+    try {
+      visible = deps.isDocumentVisible();
+    } catch {
+      return;
+    }
+    if (!link || !visible) return;
+    retryTimer = schedule(() => {
+      retryTimer = null;
+      if (disposed) return;
+      if (snapshot.state !== "offline") return;
+      try {
+        if (!deps.getNavigatorOnline() || !deps.isDocumentVisible()) {
+          scheduleRetryIfNeeded();
+          return;
+        }
+      } catch {
+        return;
+      }
+      runProbe({ background: true });
+    }, retryIntervalMs);
+  }
+
+  /**
+   * Single settle gate: the first settle for a generation consumes it, so
+   * a timeout abort racing a late resolve/reject can never double-apply,
+   * and superseded generations are ignored.
+   */
+  function settle(gen: number, ok: boolean): void {
+    if (gen !== generation || disposed) return;
+    generation += 1;
+    clearProbeTimer();
+    probeController = null;
+    if (ok) {
+      enterOnline();
+    } else {
+      emit({
+        state: "offline",
+        navigatorOnline: readLink(),
+        reachabilityVerified: true,
+      });
+      scheduleRetryIfNeeded();
+    }
+  }
+
+  function runProbe(options: { background: boolean }): void {
+    if (disposed) return;
+    invalidateProbe();
+    if (!options.background) enterChecking();
+    const gen = ++generation;
+    let controller: AbortController | null = null;
+    if (typeof AbortController !== "undefined") {
+      controller = new AbortController();
+      probeController = controller;
+    }
+    probeTimer = schedule(() => {
+      probeTimer = null;
+      // Settle directly: a misbehaving fetch implementation might never
+      // reject after abort, and the timeout itself is the verdict.
+      // settle() consumes the generation, so a late abort-rejection from
+      // the probe below is ignored rather than double-applied.
+      if (controller) {
+        try {
+          controller.abort();
+        } catch {
+          // The resulting rejection settles via the guarded continuation.
+        }
+      }
+      settle(gen, false);
+    }, probeTimeoutMs);
+
+    let result: Promise<boolean>;
+    try {
+      result = deps.probe(
+        controller ? controller.signal : ({} as AbortSignal),
+      );
+    } catch {
+      settle(gen, false);
+      return;
+    }
+    result.then(
+      (ok) => settle(gen, ok === true),
+      () => settle(gen, false),
+    );
+  }
+
+  function startVerificationProbe(): void {
+    runProbe({ background: false });
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+
+    handleMount: () => {
+      if (disposed) return;
+      if (!readLink()) {
+        // Definite browser offline: no pointless probe.
+        emit({
+          state: "offline",
+          navigatorOnline: false,
+          reachabilityVerified: false,
+        });
+        scheduleRetryIfNeeded();
+        return;
+      }
+      startVerificationProbe();
+    },
+
+    handleOnlineEvent: () => {
+      if (disposed) return;
+      if (snapshot.state === "online") return;
+      // Never trust the event alone (VPN false positive).
+      startVerificationProbe();
+    },
+
+    handleOfflineEvent: () => {
+      if (disposed) return;
+      enterOffline(false);
+    },
+
+    handleResync: () => {
+      if (disposed) return;
+      if (!readLink()) {
+        enterOffline(false);
+        return;
+      }
+      // Re-verify even from "online": silent death while hidden/suspended
+      // is exactly the PWA-resume gap. Cheap (one tiny 204) and rare
+      // (user-driven foregrounds only, never a poll).
+      startVerificationProbe();
+    },
+
+    dispose: () => {
+      disposed = true;
+      invalidateProbe();
+      clearRetryTimer();
+    },
+  };
+}

--- a/lib/offline/connectivity-store.test.ts
+++ b/lib/offline/connectivity-store.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ListenerRegistry {
+  window: Map<string, Set<() => void>>;
+  document: Map<string, Set<() => void>>;
+  addedCounts: Map<string, number>;
+}
+
+function installBrowserStubs(opts?: { onLine?: boolean; hidden?: boolean }) {
+  let onLine = opts?.onLine ?? true;
+  let hidden = opts?.hidden ?? false;
+  const registry: ListenerRegistry = {
+    window: new Map(),
+    document: new Map(),
+    addedCounts: new Map(),
+  };
+  const addTo =
+    (map: Map<string, Set<() => void>>) =>
+    (type: string, fn: () => void): void => {
+      if (!map.has(type)) map.set(type, new Set());
+      map.get(type)!.add(fn);
+      registry.addedCounts.set(type, (registry.addedCounts.get(type) ?? 0) + 1);
+    };
+  const windowStub = {
+    addEventListener: addTo(registry.window),
+    removeEventListener: (type: string, fn: () => void) => {
+      registry.window.get(type)?.delete(fn);
+    },
+    dispatch: (type: string) => {
+      registry.window.get(type)?.forEach((fn) => fn());
+    },
+  };
+  const documentStub = {
+    get hidden() {
+      return hidden;
+    },
+    addEventListener: addTo(registry.document),
+    removeEventListener: (type: string, fn: () => void) => {
+      registry.document.get(type)?.delete(fn);
+    },
+    dispatch: (type: string) => {
+      registry.document.get(type)?.forEach((fn) => fn());
+    },
+  };
+  const navigatorStub = {
+    get onLine() {
+      return onLine;
+    },
+  };
+  vi.stubGlobal("window", windowStub);
+  vi.stubGlobal("document", documentStub);
+  vi.stubGlobal("navigator", navigatorStub);
+  return {
+    registry,
+    setOnLine: (v: boolean) => {
+      onLine = v;
+    },
+    setHidden: (v: boolean) => {
+      hidden = v;
+    },
+    window: windowStub,
+    document: documentStub,
+  };
+}
+
+async function loadStore() {
+  vi.resetModules();
+  return await import("./connectivity-store");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("singleton connectivity store", () => {
+  it("many subscribers share one probe per transition", async () => {
+    const env = installBrowserStubs();
+    let fetchCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetchCalls += 1;
+        return { status: 204 };
+      }),
+    );
+    const store = await loadStore();
+    const seen: string[][] = [[], [], []];
+    const unsubs = [0, 1, 2].map(
+      (i) => store.subscribeConnectivity(() => {
+        seen[i].push(store.getConnectivitySnapshot().state);
+      }),
+    );
+    // Initial mount probe resolves online; every subscriber observes it,
+    // but the network is hit exactly once.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.getConnectivitySnapshot().state).toBe("online");
+    expect(fetchCalls).toBe(1);
+    for (const states of seen) {
+      expect(states[states.length - 1]).toBe("online");
+    }
+    // One offline event → one state for all, no probe (link is down).
+    env.setOnLine(false);
+    env.window.dispatch("offline");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.getConnectivitySnapshot().state).toBe("offline");
+    expect(fetchCalls).toBe(1);
+    unsubs.forEach((u) => u());
+    store.__resetConnectivityStoreForTests();
+  });
+
+  it("registers exactly one set of listeners no matter the subscriber count", async () => {
+    installBrowserStubs();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 204 })));
+    const store = await loadStore();
+    const unsubs = Array.from({ length: 5 }, () =>
+      store.subscribeConnectivity(() => {}),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    // Re-subscribing must not add another listener set or probe.
+    const unsubs2 = Array.from({ length: 3 }, () =>
+      store.subscribeConnectivity(() => {}),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.getConnectivitySnapshot().state).toBe("online");
+    [...unsubs, ...unsubs2].forEach((u) => u());
+    store.__resetConnectivityStoreForTests();
+    // Listener registration happens once per event type at store creation.
+    // (Counts asserted via a fresh load below.)
+  });
+
+  it("counts a single listener set per event type", async () => {
+    const env = installBrowserStubs();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ status: 204 })));
+    const store = await loadStore();
+    store.subscribeConnectivity(() => {});
+    store.subscribeConnectivity(() => {});
+    store.subscribeConnectivity(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(env.registry.addedCounts.get("online")).toBe(1);
+    expect(env.registry.addedCounts.get("offline")).toBe(1);
+    expect(env.registry.addedCounts.get("pageshow")).toBe(1);
+    expect(env.registry.addedCounts.get("visibilitychange")).toBe(1);
+    store.__resetConnectivityStoreForTests();
+  });
+
+  it("single retry schedule while offline-with-link; all see recovery", async () => {
+    const env = installBrowserStubs();
+    let fetchCalls = 0;
+    let failProbes = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        fetchCalls += 1;
+        if (failProbes) throw new Error("down");
+        return { status: 204 };
+      }),
+    );
+    const store = await loadStore();
+    const lastSeen: string[] = [];
+    store.subscribeConnectivity(() => {
+      lastSeen.push(store.getConnectivitySnapshot().state);
+    });
+    store.subscribeConnectivity(() => {
+      lastSeen.push(store.getConnectivitySnapshot().state);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.getConnectivitySnapshot().state).toBe("offline");
+    expect(fetchCalls).toBe(1);
+    // Exactly one retry fires per 25 s window (single schedule).
+    await vi.advanceTimersByTimeAsync(25000);
+    expect(fetchCalls).toBe(2);
+    // Recovery: both subscribers observe online, cadence stops.
+    failProbes = false;
+    await vi.advanceTimersByTimeAsync(25000);
+    expect(store.getConnectivitySnapshot().state).toBe("online");
+    expect(lastSeen[lastSeen.length - 1]).toBe("online");
+    const afterRecovery = fetchCalls;
+    await vi.advanceTimersByTimeAsync(100000);
+    expect(fetchCalls).toBe(afterRecovery);
+    expect(env.registry.addedCounts.get("online")).toBe(1);
+    store.__resetConnectivityStoreForTests();
+  });
+});

--- a/lib/offline/connectivity-store.ts
+++ b/lib/offline/connectivity-store.ts
@@ -1,0 +1,119 @@
+import {
+  createConnectivityMachine,
+  type ConnectivityMachine,
+  type ConnectivitySnapshot,
+} from "./connectivity-machine";
+
+export type {
+  ConnectivitySnapshot,
+  ConnectivityState,
+} from "./connectivity-machine";
+
+async function fetchConnectivity(signal: AbortSignal): Promise<boolean> {
+  const res = await fetch("/api/connectivity", {
+    cache: "no-store",
+    signal,
+  });
+  return res.status === 204;
+}
+
+const SERVER_SNAPSHOT: ConnectivitySnapshot = {
+  state: "checking",
+  navigatorOnline: true,
+  reachabilityVerified: false,
+};
+
+// Module-level singleton: exactly one machine, one listener set, one
+// in-flight probe and one retry timer per page, no matter how many
+// components subscribe. Created lazily on first client use so server
+// rendering never touches browser globals.
+let machine: ConnectivityMachine | null = null;
+let machineSnapshot: ConnectivitySnapshot = SERVER_SNAPSHOT;
+const machineListeners = new Set<() => void>();
+
+function readLink(): boolean {
+  try {
+    return typeof navigator === "undefined"
+      ? true
+      : navigator.onLine !== false;
+  } catch {
+    return true;
+  }
+}
+
+function readVisible(): boolean {
+  try {
+    return typeof document === "undefined" ? true : !document.hidden;
+  } catch {
+    return true;
+  }
+}
+
+export function ensureConnectivityStore(): ConnectivityMachine {
+  if (machine) return machine;
+  const created = createConnectivityMachine({
+    getNavigatorOnline: readLink,
+    isDocumentVisible: readVisible,
+    probe: fetchConnectivity,
+    onChange: (snapshot) => {
+      machineSnapshot = snapshot;
+      machineListeners.forEach((listener) => {
+        try {
+          listener();
+        } catch {
+          // A broken listener must not break the others.
+        }
+      });
+    },
+  });
+  machine = created;
+  if (typeof window !== "undefined") {
+    const onOnline = () => created.handleOnlineEvent();
+    const onOffline = () => created.handleOfflineEvent();
+    const onShow = () => created.handleResync();
+    const onVisibility = () => {
+      try {
+        if (!document.hidden) created.handleResync();
+      } catch {
+        // Ignore.
+      }
+    };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+    window.addEventListener("pageshow", onShow);
+    document.addEventListener("visibilitychange", onVisibility);
+    // Listeners live for the page lifetime by design (single set); the
+    // machine itself is never disposed — it IS the page's connectivity.
+    created.handleMount();
+  }
+  return created;
+}
+
+export function subscribeConnectivity(listener: () => void): () => void {
+  ensureConnectivityStore();
+  machineListeners.add(listener);
+  return () => {
+    machineListeners.delete(listener);
+  };
+}
+
+export function getConnectivitySnapshot(): ConnectivitySnapshot {
+  ensureConnectivityStore();
+  return machineSnapshot;
+}
+
+export function getServerConnectivitySnapshot(): ConnectivitySnapshot {
+  return SERVER_SNAPSHOT;
+}
+
+/** Test-only: drop the singleton so tests start isolated. */
+export function __resetConnectivityStoreForTests(): void {
+  try {
+    machine?.dispose();
+  } catch {
+    // Ignore.
+  }
+  machine = null;
+  machineSnapshot = SERVER_SNAPSHOT;
+  machineListeners.clear();
+}

--- a/lib/offline/document-fallback.test.ts
+++ b/lib/offline/document-fallback.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANONICAL_STATIC_DOCS,
+  canonicalDocFallbackFor,
+  isCanonicalStaticDoc,
+} from "./document-fallback";
+
+const ORIGIN = "https://metto.ir";
+
+function nav(url: string, mode = "navigate", destination = "document") {
+  return { mode, destination, url, origin: ORIGIN };
+}
+
+describe("isCanonicalStaticDoc", () => {
+  it("matches exactly the four static documents", () => {
+    expect(CANONICAL_STATIC_DOCS).toEqual(["/", "/map", "/stations", "/nearby"]);
+    for (const p of ["/", "/map", "/stations", "/nearby"]) {
+      expect(isCanonicalStaticDoc(p)).toBe(true);
+    }
+  });
+
+  it("rejects everything else", () => {
+    for (const p of [
+      "/map/",
+      "/stations/123",
+      "/api/route",
+      "/api/holidays",
+      "/manifest.webmanifest",
+      "/schedule-data.json",
+      "/holidays.json",
+      "",
+      "map",
+    ]) {
+      expect(isCanonicalStaticDoc(p)).toBe(false);
+    }
+  });
+});
+
+describe("canonicalDocFallbackFor", () => {
+  it("maps query-bearing navigations to their canonical document", () => {
+    expect(
+      canonicalDocFallbackFor("/map", nav(`${ORIGIN}/map?from=ahang&to=aliabad`)),
+    ).toBe("/map");
+    expect(
+      canonicalDocFallbackFor(
+        "/nearby",
+        nav(`${ORIGIN}/nearby?from=tajrish&to=tehran-sadeghiyeh&x=1`),
+      ),
+    ).toBe("/nearby");
+    expect(
+      canonicalDocFallbackFor("/stations", nav(`${ORIGIN}/stations?from=ahang`)),
+    ).toBe("/stations");
+    expect(
+      canonicalDocFallbackFor("/", nav(`${ORIGIN}/?from=ahang&to=aliabad`)),
+    ).toBe("/");
+  });
+
+  it("never cross-matches another known page (no / fallback for /map)", () => {
+    expect(
+      canonicalDocFallbackFor("/", nav(`${ORIGIN}/map?from=ahang`)),
+    ).toBeNull();
+    expect(
+      canonicalDocFallbackFor("/map", nav(`${ORIGIN}/stations?from=ahang`)),
+    ).toBeNull();
+  });
+
+  it("rejects non-navigations: RSC, prefetch, subresources, API", () => {
+    // RSC/Flight payload (fetch destination is empty, mode is cors).
+    expect(
+      canonicalDocFallbackFor(
+        "/map",
+        nav(`${ORIGIN}/map?from=ahang`, "cors", ""),
+      ),
+    ).toBeNull();
+    // Prefetch-style request.
+    expect(
+      canonicalDocFallbackFor(
+        "/map",
+        nav(`${ORIGIN}/map?from=ahang`, "no-cors", ""),
+      ),
+    ).toBeNull();
+    expect(
+      canonicalDocFallbackFor("/map", nav(`${ORIGIN}/map`, "navigate", "image")),
+    ).toBeNull();
+    expect(
+      canonicalDocFallbackFor("/api/route", nav(`${ORIGIN}/api/route?from=ahang`)),
+    ).toBeNull();
+  });
+
+  it("rejects cross-origin and malformed URLs", () => {
+    expect(
+      canonicalDocFallbackFor("/map", {
+        ...nav(`${ORIGIN}/map`),
+        url: "https://evil.example/map?from=ahang",
+      }),
+    ).toBeNull();
+    expect(
+      canonicalDocFallbackFor("/map", nav("::not-a-url::")),
+    ).toBeNull();
+  });
+});

--- a/lib/offline/document-fallback.ts
+++ b/lib/offline/document-fallback.ts
@@ -1,0 +1,61 @@
+/**
+ * Narrow offline document fallback for the top-level static tabs.
+ *
+ * Background: Serwist precaches canonical documents (`/`, `/map`,
+ * `/stations`, `/nearby`) but only strips `utm_*`/`fbclid` query params
+ * when matching, so a navigation like `/map?from=ahang&to=aliabad` misses
+ * the precache entry. The fallback below maps such requests back to their
+ * canonical precached document — normalizing ONLY for the cache lookup.
+ * The browser URL is never mutated or redirected.
+ *
+ * Rules encoded here (and mirrored in `app/sw.ts` fallback entries):
+ * - same-origin only;
+ * - full document navigations only (`request.mode === "navigate"`,
+ *   defensively also `destination === "document"`) — RSC/Flight, API,
+ *   assets and tiles can never match;
+ * - exact pathname must be one of the four canonical static documents;
+ * - unknown paths match nothing and fail normally offline.
+ */
+
+export const CANONICAL_STATIC_DOCS: ReadonlyArray<string> = [
+  "/",
+  "/map",
+  "/stations",
+  "/nearby",
+];
+
+/** Exact-match check against the canonical static documents. */
+export function isCanonicalStaticDoc(pathname: string): boolean {
+  return (CANONICAL_STATIC_DOCS as ReadonlyArray<string>).includes(pathname);
+}
+
+export interface DocumentFallbackRequestShape {
+  mode: string;
+  destination: string;
+  url: string;
+  origin: string;
+}
+
+/**
+ * True when an offline-failed request should fall back to the precached
+ * canonical document for `pathname`. Returns the canonical pathname to
+ * look up (always identical to the entry's own pathname), or null.
+ */
+export function canonicalDocFallbackFor(
+  pathname: `/${string}`,
+  req: DocumentFallbackRequestShape,
+): `/${string}` | null {
+  if (req.mode !== "navigate") return null;
+  // Defensive: navigation mode is the semantic criterion; destination is
+  // an extra guard so non-document fetches can never match.
+  if (req.destination !== "" && req.destination !== "document") return null;
+  let url: URL;
+  try {
+    url = new URL(req.url, req.origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== req.origin) return null;
+  if (url.pathname !== pathname) return null;
+  return isCanonicalStaticDoc(pathname) ? pathname : null;
+}

--- a/lib/offline/use-connectivity.test.ts
+++ b/lib/offline/use-connectivity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { isPrecachedTabUrl, shouldInterceptOfflineNav } from "./use-connectivity";
+
+describe("isPrecachedTabUrl", () => {
+  it("matches the four precached static tabs", () => {
+    expect(isPrecachedTabUrl("/")).toBe(true);
+    expect(isPrecachedTabUrl("/stations")).toBe(true);
+    expect(isPrecachedTabUrl("/nearby")).toBe(true);
+    expect(isPrecachedTabUrl("/map")).toBe(true);
+  });
+
+  it("ignores query strings and hashes (route state is preserved)", () => {
+    expect(isPrecachedTabUrl("/?from=ahang&to=aliabad")).toBe(true);
+    expect(isPrecachedTabUrl("/map?from=ahang")).toBe(true);
+    expect(isPrecachedTabUrl("/stations#list")).toBe(true);
+  });
+
+  it("rejects dynamic, API, and external URLs", () => {
+    expect(isPrecachedTabUrl("/api/route")).toBe(false);
+    expect(isPrecachedTabUrl("/stations/123")).toBe(false);
+    expect(isPrecachedTabUrl("/map/extra/path")).toBe(false);
+    expect(isPrecachedTabUrl("https://metto.ir/map")).toBe(false);
+    expect(isPrecachedTabUrl("https://github.com/aliinreallife")).toBe(false);
+    expect(isPrecachedTabUrl("")).toBe(false);
+    expect(isPrecachedTabUrl("/MAP")).toBe(false);
+  });
+});
+
+describe("shouldInterceptOfflineNav", () => {
+  const plain = {
+    button: 0,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  it("allows an ordinary same-tab primary click", () => {
+    expect(shouldInterceptOfflineNav(plain)).toBe(true);
+    expect(shouldInterceptOfflineNav({ ...plain, target: "_self" })).toBe(true);
+    expect(shouldInterceptOfflineNav({ ...plain, target: null })).toBe(true);
+  });
+
+  it("never intercepts modifier, middle-click, or new-tab navigation", () => {
+    expect(shouldInterceptOfflineNav({ ...plain, button: 1 })).toBe(false);
+    expect(shouldInterceptOfflineNav({ ...plain, button: 2 })).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, ctrlKey: true }),
+    ).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, metaKey: true }),
+    ).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, shiftKey: true }),
+    ).toBe(false);
+    expect(shouldInterceptOfflineNav({ ...plain, altKey: true })).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, target: "_blank" }),
+    ).toBe(false);
+  });
+});

--- a/lib/offline/use-connectivity.ts
+++ b/lib/offline/use-connectivity.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Single reliable client-side connectivity source for the whole app.
+ *
+ * Based primarily on `navigator.onLine`, resynchronized on:
+ * - initial client mount,
+ * - `window` online / offline events,
+ * - `pageshow` (back/forward cache restores, PWA resume),
+ * - `visibilitychange` when the document becomes visible again
+ *   (an installed PWA may have slept through a connectivity change).
+ *
+ * Deliberately NOT derived from tile/API failures: a CARTO CDN failure
+ * while `navigator.onLine === true` must never mark the device offline.
+ */
+export function useConnectivity(): boolean {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine !== false,
+  );
+
+  useEffect(() => {
+    const sync = () => {
+      try {
+        setOnline(navigator.onLine !== false);
+      } catch {
+        // Keep the last known value if unreadable.
+      }
+    };
+    // Align immediately on mount in case connectivity changed while
+    // suspended/backgrounded before this component mounted.
+    sync();
+    const onVisibility = () => {
+      if (!document.hidden) sync();
+    };
+    window.addEventListener("online", sync);
+    window.addEventListener("offline", sync);
+    window.addEventListener("pageshow", sync);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("online", sync);
+      window.removeEventListener("offline", sync);
+      window.removeEventListener("pageshow", sync);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return online;
+}
+
+/** Top-level static tabs known to be in the Serwist precache. */
+const PRECACHED_TABS: ReadonlySet<string> = new Set([
+  "/",
+  "/stations",
+  "/nearby",
+  "/map",
+]);
+
+/**
+ * True for the top-level static tab URLs that are guaranteed precached,
+ * so an offline full-document navigation to them is safe. Query strings
+ * are ignored (`/?from=…` maps to `/`); dynamic/API/external URLs are
+ * never matched.
+ */
+export function isPrecachedTabUrl(href: string): boolean {
+  if (!href.startsWith("/")) return false;
+  const pathname = href.split("?", 1)[0].split("#", 1)[0] || "/";
+  return PRECACHED_TABS.has(pathname);
+}
+
+export interface PrimaryClickShape {
+  button: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  target?: string | null;
+}
+
+/**
+ * True only for an ordinary same-tab primary-button navigation — the one
+ * case where offline tab links fall back to `window.location.assign`.
+ * Modifier/middle clicks, new-tab targets and anything else keep normal
+ * browser link semantics and are never intercepted.
+ */
+export function shouldInterceptOfflineNav(e: PrimaryClickShape): boolean {
+  if (e.button !== 0) return false;
+  if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return false;
+  if (e.target && e.target !== "_self") return false;
+  return true;
+}

--- a/lib/offline/use-connectivity.ts
+++ b/lib/offline/use-connectivity.ts
@@ -1,52 +1,50 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
+import {
+  getConnectivitySnapshot,
+  getServerConnectivitySnapshot,
+  subscribeConnectivity,
+  type ConnectivitySnapshot,
+  type ConnectivityState,
+} from "./connectivity-store";
+
+export type { ConnectivityState };
+
+export interface ConnectivityValue {
+  state: ConnectivityState;
+  /** True only when reachability was verified (state === "online"). */
+  online: boolean;
+  /** False while the first/renewed verification is still running. */
+  verified: boolean;
+  /** Raw link flag last observed (diagnostics only — never UI truth). */
+  navigatorOnline: boolean;
+  /** True once a probe resolved for the current episode. */
+  reachabilityVerified: boolean;
+}
+
+function toValue(snapshot: ConnectivitySnapshot): ConnectivityValue {
+  return {
+    state: snapshot.state,
+    online: snapshot.state === "online",
+    verified: snapshot.state !== "checking",
+    navigatorOnline: snapshot.navigatorOnline,
+    reachabilityVerified: snapshot.reachabilityVerified,
+  };
+}
 
 /**
- * Single reliable client-side connectivity source for the whole app.
- *
- * Based primarily on `navigator.onLine`, resynchronized on:
- * - initial client mount,
- * - `window` online / offline events,
- * - `pageshow` (back/forward cache restores, PWA resume),
- * - `visibilitychange` when the document becomes visible again
- *   (an installed PWA may have slept through a connectivity change).
- *
- * Deliberately NOT derived from tile/API failures: a CARTO CDN failure
- * while `navigator.onLine === true` must never mark the device offline.
+ * The single shared effective-connectivity state. Safe to call from any
+ * number of components — all observe the same value, driven by one probe
+ * at a time. Deliberately NOT derived from tile/API failures.
  */
-export function useConnectivity(): boolean {
-  const [online, setOnline] = useState<boolean>(() =>
-    typeof navigator === "undefined" ? true : navigator.onLine !== false,
+export function useConnectivity(): ConnectivityValue {
+  const snapshot = useSyncExternalStore(
+    subscribeConnectivity,
+    getConnectivitySnapshot,
+    getServerConnectivitySnapshot,
   );
-
-  useEffect(() => {
-    const sync = () => {
-      try {
-        setOnline(navigator.onLine !== false);
-      } catch {
-        // Keep the last known value if unreadable.
-      }
-    };
-    // Align immediately on mount in case connectivity changed while
-    // suspended/backgrounded before this component mounted.
-    sync();
-    const onVisibility = () => {
-      if (!document.hidden) sync();
-    };
-    window.addEventListener("online", sync);
-    window.addEventListener("offline", sync);
-    window.addEventListener("pageshow", sync);
-    document.addEventListener("visibilitychange", onVisibility);
-    return () => {
-      window.removeEventListener("online", sync);
-      window.removeEventListener("offline", sync);
-      window.removeEventListener("pageshow", sync);
-      document.removeEventListener("visibilitychange", onVisibility);
-    };
-  }, []);
-
-  return online;
+  return toValue(snapshot);
 }
 
 /** Top-level static tabs known to be in the Serwist precache. */

--- a/lib/offline/use-offline-readiness.ts
+++ b/lib/offline/use-offline-readiness.ts
@@ -1,10 +1,11 @@
 "use client";
 
 // Offline-readiness state machine (4 states):
-// 1. "preparing": online, SW/schedule/holiday not all ready yet.
+// 1. "preparing": online-but-incomplete, OR offline with verification still
+//    pending (UNKNOWN — must never warn).
 // 2. "ready": online + SW controlling + schedule + holiday dataset present.
-// 3. "offline-ready": offline + core data available (full planner works).
-// 4. "offline-incomplete": offline but core was never initialized.
+// 3. "offline-ready": offline + verified + core data available.
+// 4. "offline-incomplete": offline + VERIFIED missing core (the only warning).
 //
 // "Core ready" NEVER claims readiness from SW install alone — the timetable
 // (`schedule-data.json`) and the holiday dataset must both be loaded.
@@ -15,7 +16,11 @@
 // no toast, no automatic reload — ever. Service-worker transitions are
 // console-only diagnostics (see logSwLifecycle).
 import { useEffect, useState } from "react";
-import { isScheduleDataLoaded, onScheduleDataReady } from "../schedule-utils";
+import {
+  isScheduleDataLoaded,
+  loadScheduleData,
+  onScheduleDataReady,
+} from "../schedule-utils";
 import { getLocalHolidayDataset } from "../holidays/use-holiday-data";
 import { useConnectivity } from "./use-connectivity";
 
@@ -34,6 +39,13 @@ export type OfflineReadiness = {
   holidayLoaded: boolean;
   precacheReady: boolean;
   coreReady: boolean;
+  /**
+   * True once the initial schedule + holiday + precache checks have EACH
+   * completed one full pass. Means "has this been checked?", not "was the
+   * required data found?". Settle (success, missing, or thrown error) counts
+   * as completed — a rejecting lookup must never leave this false forever.
+   */
+  readinessVerified: boolean;
 };
 
 // Module-level guard: one lifecycle transition logs at most once per
@@ -67,22 +79,70 @@ export function useOfflineReadiness(): OfflineReadiness {
   const [holidayLoaded, setHolidayLoaded] = useState(
     () => getLocalHolidayDataset() !== null,
   );
+  // Completion flags: each initial check settling (found, missing, or
+  // thrown) marks its flag. All three must be true before an offline
+  // document may claim anything about missing core data.
+  const [scheduleChecked, setScheduleChecked] = useState(false);
+  const [holidayChecked, setHolidayChecked] = useState(false);
+  const [precacheChecked, setPrecacheChecked] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
+    const markChecked = () => {
+      if (!cancelled) setScheduleChecked(true);
+    };
     if (isScheduleDataLoaded()) {
       setScheduleLoaded(true);
-      return;
+      markChecked();
+      return () => {
+        cancelled = true;
+      };
     }
-    return onScheduleDataReady(() => setScheduleLoaded(true));
+    const unsubscribe = onScheduleDataReady(() => {
+      if (cancelled) return;
+      setScheduleLoaded(true);
+      markChecked();
+    });
+    // Settle guard: the load promise resolves AND rejects through here, so
+    // a failed offline fetch (evicted/missing core) still completes the
+    // check instead of leaving readinessVerified false forever.
+    // loadScheduleData is deduped with the providers' call — safe to attach.
+    try {
+      const pending = loadScheduleData();
+      if (pending && typeof pending.then === "function") {
+        pending.then(markChecked, markChecked);
+      } else {
+        markChecked();
+      }
+    } catch {
+      markChecked();
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
   }, []);
 
   useEffect(() => {
     let cancelled = false;
     let timer: number | null = null;
+    let firstPassDone = false;
+    const markFirstPass = () => {
+      // The FIRST lookup settling (found, missing, or thrown) completes the
+      // check. Later 1s retries only flip precacheReady, never verification.
+      if (!firstPassDone) {
+        firstPassDone = true;
+        if (!cancelled) setPrecacheChecked(true);
+      }
+    };
     const check = async () => {
       if (cancelled) return;
+      let found = false;
       try {
-        if (typeof caches === "undefined") return;
+        if (typeof caches === "undefined") {
+          markFirstPass();
+          return;
+        }
         // Serwist precache keys carry `?__WB_REVISION__=` cache-busting
         // params (only `/_next/static/` is exempt), so match while ignoring
         // the query string. The SW's own routes resolve the same entries.
@@ -90,12 +150,17 @@ export function useOfflineReadiness(): OfflineReadiness {
           caches.match("/schedule-data.json", { ignoreSearch: true }),
           caches.match("/holidays.json", { ignoreSearch: true }),
         ]);
-        if (schedule && holidays) {
-          setPrecacheReady(true);
-          return;
-        }
+        if (cancelled) return;
+        found = !!(schedule && holidays);
       } catch {
-        // Cache Storage unreadable — stay in "preparing".
+        // Cache Storage unreadable — still a completed pass, never hang.
+        found = false;
+      }
+      if (cancelled) return;
+      markFirstPass();
+      if (found) {
+        setPrecacheReady(true);
+        return;
       }
       timer = window.setTimeout(check, 1000);
     };
@@ -107,16 +172,26 @@ export function useOfflineReadiness(): OfflineReadiness {
   }, []);
 
   useEffect(() => {
-    // Holiday dataset ships bundled, so this is instant in practice; the
-    // poll covers the LKG-storage path resolving after mount.
-    if (getLocalHolidayDataset() !== null) {
-      setHolidayLoaded(true);
-      return;
-    }
-    const t = window.setInterval(() => {
+    // Holiday dataset ships bundled, so the sync read below settles the
+    // check immediately in practice; errors count as settled too. The poll
+    // covers the LKG-storage path resolving after mount and only affects
+    // the loaded flag, never verification.
+    try {
       if (getLocalHolidayDataset() !== null) {
         setHolidayLoaded(true);
-        window.clearInterval(t);
+      }
+    } catch {
+      // Sync read failed — still a completed pass.
+    }
+    setHolidayChecked(true);
+    const t = window.setInterval(() => {
+      try {
+        if (getLocalHolidayDataset() !== null) {
+          setHolidayLoaded(true);
+          window.clearInterval(t);
+        }
+      } catch {
+        // Keep polling until the stop timer; verification already done.
       }
     }, 500);
     const stop = window.setTimeout(() => window.clearInterval(t), 10000);
@@ -203,15 +278,24 @@ export function useOfflineReadiness(): OfflineReadiness {
 
   const coreReady = scheduleLoaded && holidayLoaded;
 
-  // Tri-state aware: "checking" is neither online nor offline — it follows
-  // the online path (preparing/ready) so nothing offline is ever claimed
-  // before reachability resolves.
+  // Verified-readiness gate (UNKNOWN vs MISSING): an offline document whose
+  // three initial checks have not all settled yet reports "preparing", never
+  // "offline-incomplete". Only a settled check run with missing core data
+  // may show the amber warning — a slow phone/cache must never warn merely
+  // because verification took longer than the UI grace period.
+  // Tri-state aware: "checking" connectivity is neither online nor offline —
+  // it follows the online path (preparing/ready) so nothing offline is ever
+  // claimed before reachability resolves.
+  const readinessVerified =
+    scheduleChecked && holidayChecked && precacheChecked;
   const confirmedOffline = connectivity.state === "offline";
 
   let phase: OfflinePhase;
   if (!confirmedOffline) {
     phase =
       coreReady && swControlling && precacheReady ? "ready" : "preparing";
+  } else if (!readinessVerified) {
+    phase = "preparing";
   } else {
     phase = coreReady ? "offline-ready" : "offline-incomplete";
   }
@@ -225,5 +309,6 @@ export function useOfflineReadiness(): OfflineReadiness {
     holidayLoaded,
     precacheReady,
     coreReady,
+    readinessVerified,
   };
 }

--- a/lib/offline/use-offline-readiness.ts
+++ b/lib/offline/use-offline-readiness.ts
@@ -17,6 +17,7 @@
 import { useEffect, useState } from "react";
 import { isScheduleDataLoaded, onScheduleDataReady } from "../schedule-utils";
 import { getLocalHolidayDataset } from "../holidays/use-holiday-data";
+import { useConnectivity } from "./use-connectivity";
 
 export type OfflinePhase =
   | "preparing"
@@ -46,9 +47,10 @@ function logSwLifecycle(message: string): void {
 }
 
 export function useOfflineReadiness(): OfflineReadiness {
-  const [online, setOnline] = useState<boolean>(() =>
-    typeof navigator === "undefined" ? true : navigator.onLine !== false,
-  );
+  // Single shared effective-connectivity state — this module no longer
+  // tracks online/offline itself (it used to, and the two could disagree).
+  const connectivity = useConnectivity();
+  const online = connectivity.online;
   const [swControlling, setSwControlling] = useState(false);
   const [swWaiting, setSwWaiting] = useState(false);
   const [scheduleLoaded, setScheduleLoaded] = useState(() => {
@@ -65,17 +67,6 @@ export function useOfflineReadiness(): OfflineReadiness {
   const [holidayLoaded, setHolidayLoaded] = useState(
     () => getLocalHolidayDataset() !== null,
   );
-
-  useEffect(() => {
-    const onOnline = () => setOnline(true);
-    const onOffline = () => setOnline(false);
-    window.addEventListener("online", onOnline);
-    window.addEventListener("offline", onOffline);
-    return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener("offline", onOffline);
-    };
-  }, []);
 
   useEffect(() => {
     if (isScheduleDataLoaded()) {
@@ -212,13 +203,17 @@ export function useOfflineReadiness(): OfflineReadiness {
 
   const coreReady = scheduleLoaded && holidayLoaded;
 
+  // Tri-state aware: "checking" is neither online nor offline — it follows
+  // the online path (preparing/ready) so nothing offline is ever claimed
+  // before reachability resolves.
+  const confirmedOffline = connectivity.state === "offline";
+
   let phase: OfflinePhase;
-  if (!online) {
-    phase = coreReady ? "offline-ready" : "offline-incomplete";
-  } else if (coreReady && swControlling && precacheReady) {
-    phase = "ready";
+  if (!confirmedOffline) {
+    phase =
+      coreReady && swControlling && precacheReady ? "ready" : "preparing";
   } else {
-    phase = "preparing";
+    phase = coreReady ? "offline-ready" : "offline-incomplete";
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts tests/map-reconnect.spec.ts tests/offline-nav.spec.ts",
+    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts tests/map-reconnect.spec.ts tests/offline-nav.spec.ts tests/connectivity.spec.ts",
     "holidays:sync": "node scripts/sync-holidays.mjs",
     "generate:stations": "node scripts/generate-stations.ts"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts",
+    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts tests/map-reconnect.spec.ts tests/offline-nav.spec.ts",
     "holidays:sync": "node scripts/sync-holidays.mjs",
     "generate:stations": "node scripts/generate-stations.ts"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   timeout: 120_000,
   expect: { timeout: 20_000 },
   fullyParallel: false,
+  // Serial: offline tests mutate shared server state (one spec rewrites
+  // public/sw.js to simulate a release) and assert timing-sensitive SW
+  // cache contents; parallelism makes both flaky.
+  workers: 1,
   retries: 0,
   reporter: "list",
   use: {

--- a/tests/connectivity.spec.ts
+++ b/tests/connectivity.spec.ts
@@ -1,0 +1,330 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+// Effective-connectivity (verified reachability) regression suite.
+// Uses the mobile viewport so the bottom tab bar is exercised.
+// never touches live Nominatim/CARTO/Esri/upstream-holiday (intercepted);
+// /api/connectivity is served by the real local prod server except where
+// a test deliberately breaks it to simulate VPN-style false-online.
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+// Effective-connectivity (verified reachability) regression suite.
+// never touches live Nominatim/CARTO/Esri/upstream-holiday (intercepted);
+// /api/connectivity is served by the real local prod server except where
+// a test deliberately breaks it to simulate VPN-style false-online.
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+const THIRD_PARTY = [
+  "**://nominatim.openstreetmap.org/**",
+  "**://*.arcgisonline.com/**",
+  "**://api.timestamp.ir/**",
+];
+
+async function blockThirdParty(context: BrowserContext) {
+  for (const pattern of THIRD_PARTY) {
+    await context.route(pattern, (route) => route.abort("blockedbyclient"));
+  }
+}
+
+async function mockTiles(context: BrowserContext) {
+  await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "image/png",
+      headers: { "Access-Control-Allow-Origin": "*" },
+      body: PNG_1PX,
+    }),
+  );
+}
+
+async function waitForOfflineReady(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect(status).toBeAttached({ timeout: 60_000 });
+  await expect
+    .poll(
+      async () =>
+        status.getAttribute("data-phase").then((p) => p ?? "unknown"),
+      { timeout: 60_000 },
+    )
+    .not.toBe("preparing");
+  const phase = await status.getAttribute("data-phase");
+  expect(["ready", "offline-ready"]).toContain(phase);
+}
+
+/** The mobile bottom tab bar. */
+function bottomNav(page: Page) {
+  return page.locator("div.fixed.bottom-0 nav");
+}
+
+function tabLink(page: Page, name: string) {
+  return bottomNav(page).getByRole("link", { name, exact: true });
+}
+
+async function connectivityOf(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () =>
+      (window as unknown as { __mettoOffline?: { connectivity?: string } })
+        .__mettoOffline?.connectivity ?? null,
+  );
+}
+
+const WARN_TEXT = "آماده نشده است";
+const OLD_PREP_TEXT = "در حال آماده";
+
+test.describe("Effective connectivity", () => {
+  test("A. online init shows no preparation or ready status", async ({
+    context,
+  }) => {
+    await blockThirdParty(context);
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    const status = page.getByTestId("offline-status");
+    await expect(status).toBeAttached({ timeout: 60_000 });
+    // Sample through the ENTIRE preparing window, not just final state.
+    for (let i = 0; i < 60; i++) {
+      const phase = await status.getAttribute("data-phase");
+      expect(await page.getByText(WARN_TEXT).count()).toBe(0);
+      expect(await page.getByText(OLD_PREP_TEXT).count()).toBe(0);
+      if (phase !== "preparing") break;
+      await page.waitForTimeout(500);
+      if (i === 59) throw new Error("never left preparing");
+    }
+    expect(await status.getAttribute("data-phase")).toBe("ready");
+  });
+
+  test("C. brief flap shows no warning flash", async ({ context }) => {
+    await blockThirdParty(context);
+    // Hold core readiness back so the warning COULD appear (proves grace).
+    await context.route("**/schedule-data.json", (route) =>
+      route.abort("blockedbyclient"),
+    );
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("offline-status")).toBeAttached({
+      timeout: 60_000,
+    });
+    // Offline blip well inside the ~1.75 s warning grace, then recover.
+    await context.setOffline(true);
+    await page.waitForTimeout(500);
+    await context.setOffline(false);
+    // Sample through recovery: warning must never have rendered.
+    for (let i = 0; i < 12; i++) {
+      expect(await page.getByText(WARN_TEXT).count()).toBe(0);
+      await page.waitForTimeout(300);
+    }
+    await context.unroute("**/schedule-data.json");
+  });
+
+  test("D. VPN-style false online drives offline UI without browser events", async ({
+    context,
+  }) => {
+    // Break reachability BEFORE the first mount probe. The mount probe
+    // fires during hydration — long before any worker can control the
+    // page — so interception reliably applies exactly once here. (After
+    // a worker takes control, its subrequests bypass route interception;
+    // that is a test-observability limit, not an app bug.)
+    await blockThirdParty(context);
+    await mockTiles(context);
+    await context.route("**/api/connectivity", (route) =>
+      route.abort("failed"),
+    );
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Offline UI with zero browser events dispatched in this test.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Diagnostics distinguish link state from effective reachability.
+    const diag = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __mettoOffline?: Record<string, unknown>;
+          }
+        ).__mettoOffline,
+    );
+    expect(diag?.connectivity).toBe("offline");
+    expect(diag?.navigatorOnline).toBe(true);
+
+    // Core was ready, so no global warning — only the map banner.
+    expect(await page.getByText(WARN_TEXT).count()).toBe(0);
+  });
+
+  test("E. visible-only retry recovers without events, redraws once, no reload", async ({
+    context,
+  }) => {
+    await blockThirdParty(context);
+    await mockTiles(context);
+    // Abort installed before the mount probe so the app starts offline.
+    // (Post-control probes bypass interception and hit the live local
+    // server — which is exactly what lets the retry below succeed.)
+    await context.route("**/api/connectivity", (route) =>
+      route.abort("failed"),
+    );
+    const page = await context.newPage();
+    const tileRequests: number[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("basemaps.cartocdn.com")) tileRequests.push(Date.now());
+    });
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await page.evaluate(() => {
+      (window as unknown as { __e2eNoReload?: number }).__e2eNoReload = 1;
+    });
+
+    // Still offline well before the ~25 s retry window: no spurious
+    // recovery, and no browser event is dispatched anywhere in this test.
+    await page.waitForTimeout(10000);
+    expect(await connectivityOf(page)).toBe("offline");
+
+    // Evict tiles so the post-recovery redraw must hit the network
+    // (observably proving it fired).
+    await page.evaluate(() => caches.delete("metto-carto-tiles"));
+    tileRequests.length = 0;
+
+    // Only the visible-only retry (~25 s cadence) can notice recovery.
+    // Sample connectivity edges meanwhile.
+    const edges: string[] = [];
+    let last = "offline";
+    await expect
+      .poll(
+        async () => {
+          const c = await connectivityOf(page);
+          if (c && c !== last) {
+            edges.push(`${last}->${c}`);
+            last = c;
+          }
+          return c;
+        },
+        { timeout: 90_000 },
+      )
+      .toBe("online");
+    // Exactly one offline→online edge (no flapping, single redraw trigger).
+    expect(edges.filter((e) => e === "offline->online")).toHaveLength(1);
+
+    // Banner clears, tiles retry after the transition, page never reloaded.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() => Promise.resolve(tileRequests.length), {
+        timeout: 20_000,
+      })
+      .toBeGreaterThan(0);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __e2eNoReload?: number }).__e2eNoReload,
+      ),
+    ).toBe(1);
+  });
+
+  test("F. foreground resync detects changed reachability", async ({
+    context,
+  }) => {
+    await blockThirdParty(context);
+    // Abort installed before the mount probe so the app starts offline.
+    await context.route("**/api/connectivity", (route) =>
+      route.abort("failed"),
+    );
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByTestId("offline-status"),
+    ).toBeAttached({ timeout: 60_000 });
+    await expect
+      .poll(() => connectivityOf(page), { timeout: 15_000 })
+      .toBe("offline");
+
+    // Restore reachability at the network layer (the abort is bypassed
+    // once the worker controls the page — restoration is what matters),
+    // then resync via foreground visibility WITHOUT any online event.
+    await context.unroute("**/api/connectivity");
+    await page.evaluate(() =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+    await expect
+      .poll(() => connectivityOf(page), { timeout: 15_000 })
+      .toBe("online");
+  });
+
+  test("connectivity endpoint is never cached", async ({ context }) => {
+    await blockThirdParty(context);
+    // Disable worker registration for this test via init script: with no
+    // worker ever taking control, every probe stays page-initiated and
+    // therefore countable. (Worker-initiated subrequests bypass route
+    // interception, which would make repeated probes unobservable.) The
+    // app runs fine without a controller; nothing here needs precache.
+    await context.addInitScript(() => {
+      try {
+        const container = navigator.serviceWorker;
+        if (container) {
+          Object.defineProperty(container, "register", {
+            value: () => Promise.reject(new Error("e2e: sw disabled")),
+            configurable: true,
+          });
+        }
+      } catch {
+        // If stubbing fails, the controller assertion below will catch it.
+      }
+    });
+    let hits = 0;
+    await context.route("**/api/connectivity", async (route) => {
+      hits += 1;
+      await route.fallback();
+    });
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByTestId("offline-status")).toBeAttached({
+      timeout: 60_000,
+    });
+    // Mount probe + forced resync rounds, all observable page-initiated.
+    // (No readiness wait here on purpose — readiness needs a controller.)
+    await page.evaluate(() => window.dispatchEvent(new Event("pageshow")));
+    await page.waitForTimeout(300);
+    await page.evaluate(() => window.dispatchEvent(new Event("pageshow")));
+    await page.waitForTimeout(300);
+    await page.evaluate(() => window.dispatchEvent(new Event("pageshow")));
+    await expect
+      .poll(() => Promise.resolve(hits), { timeout: 20_000 })
+      .toBeGreaterThanOrEqual(3);
+    // Guard the observability premise itself: no controller may have
+    // existed, otherwise probes could have bypassed interception unseen.
+    expect(
+      await page.evaluate(() => !!navigator.serviceWorker.controller),
+    ).toBe(false);
+    // No layer may have stored it: precache, runtime, metto-pages, other.
+    const cached = await page.evaluate(async () => {
+      const found: string[] = [];
+      for (const name of await caches.keys()) {
+        const cache = await caches.open(name);
+        for (const req of await cache.keys()) {
+          if (req.url.includes("connectivity")) found.push(`${name} :: ${req.url}`);
+        }
+      }
+      return found;
+    });
+    expect(cached).toEqual([]);
+    // And it answers 204 with no-store directly.
+    const direct = await page.evaluate(async () => {
+      const res = await fetch("/api/connectivity", { cache: "no-store" });
+      return {
+        status: res.status,
+        cc: res.headers.get("cache-control"),
+      };
+    });
+    expect(direct.status).toBe(204);
+    expect(direct.cc).toContain("no-store");
+  });
+});

--- a/tests/map-reconnect.spec.ts
+++ b/tests/map-reconnect.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+// Map recovery + deterministic offline banner. Mocked CARTO tiles only,
+// no live servers.
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+async function waitForOfflineReady(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect(status).toBeAttached({ timeout: 60_000 });
+  await expect
+    .poll(
+      async () =>
+        status.getAttribute("data-phase").then((p) => p ?? "unknown"),
+      { timeout: 60_000 },
+    )
+    .not.toBe("preparing");
+  const phase = await status.getAttribute("data-phase");
+  expect(["ready", "offline-ready"]).toContain(phase);
+}
+
+async function cachedTileCount(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    try {
+      const cache = await caches.open("metto-carto-tiles");
+      return (await cache.keys()).length;
+    } catch {
+      return 0;
+    }
+  });
+}
+
+test.describe("Map reconnect recovery", () => {
+  test.beforeEach(async ({ context }: { context: BrowserContext }) => {
+    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: PNG_1PX,
+      }),
+    );
+  });
+
+  test("missing tiles reload on reconnect without pan, zoom, or reload", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await waitForOfflineReady(page);
+    // Nudge the view once so tile requests happen while the worker
+    // controls the page (initial-load tiles may predate control).
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await page.waitForTimeout(1500);
+    await expect
+      .poll(() => cachedTileCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    // Go offline (dropping the tile mock so fetches genuinely fail) and
+    // open a far, never-viewed area via document navigation.
+    await context.setOffline(true);
+    await context.unroute("https://*.basemaps.cartocdn.com/**");
+    await page.goto("/map?map=35.85,51.65,12", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    // Failed tiles stay in the DOM without the loaded marker.
+    const errorTileSrcs = (): Promise<string[]> =>
+      page.evaluate(() =>
+        [...document.querySelectorAll("img.leaflet-tile")]
+          .filter(
+            (img) =>
+              !(img as HTMLImageElement).classList.contains(
+                "leaflet-tile-loaded",
+              ),
+          )
+          .map((img) => (img as HTMLImageElement).src),
+      );
+    await expect
+      .poll(async () => (await errorTileSrcs()).length, { timeout: 20_000 })
+      .toBeGreaterThan(0);
+    const failedUrls = await errorTileSrcs();
+    expect(failedUrls.length).toBeGreaterThan(0);
+
+    // Record view state, then reconnect WITHOUT any further gesture.
+    // Re-register the tile mock to stand in for the restored network so
+    // the test stays hermetic (no live tile servers).
+    await page.evaluate(() => {
+      (window as unknown as { __reconnectMarker?: number }).__reconnectMarker = 1;
+    });
+    const hrefBefore = page.url();
+    await context.setOffline(false);
+    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: PNG_1PX,
+      }),
+    );
+
+    // The exact previously-failed tiles must load on their own: same view,
+    // no pan/zoom/reset — recovery targets what is visible.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (srcs: string[]) => {
+            const loaded = new Set(
+              [...document.querySelectorAll("img.leaflet-tile-loaded")].map(
+                (img) => (img as HTMLImageElement).src,
+              ),
+            );
+            return srcs.filter((s) => loaded.has(s)).length;
+          }, failedUrls),
+        { timeout: 20_000 },
+      )
+      .toBe(failedUrls.length);
+
+    // No reload, no navigation, no view reset for the recovery itself.
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __reconnectMarker?: number }).__reconnectMarker,
+      ),
+    ).toBe(1);
+    expect(page.url()).toBe(hrefBefore);
+    // Offline banner is gone once back online.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("offline banner tracks connectivity even with cached tiles", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await waitForOfflineReady(page);
+    // Same nudge: ensure post-control tile requests exist to cache.
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await page.waitForTimeout(1500);
+    await expect
+      .poll(() => cachedTileCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    // Online: no banner.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+
+    // Offline: banner appears even though visible tiles serve from cache.
+    await context.setOffline(true);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/قبلاً دیده‌اید/)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Model PWA resume: connectivity resync via dispatched events.
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("offline"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Back online: banner removes itself automatically, no success toast.
+    await context.setOffline(false);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("save notice shows once while online, never stacked offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // First online visit: informational notice, info styling, no cache words.
+    await expect(
+      page.getByText("ذخیره برای استفاده آفلاین", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Dismiss persists: reload online → notice gone.
+    await page.getByRole("button", { name: "بستن" }).first().click();
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByText("ذخیره برای استفاده آفلاین", { exact: true }),
+    ).toHaveCount(0);
+
+    // Offline visit shape: offline banner wins, no stacking.
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await context.setOffline(false);
+  });
+});

--- a/tests/map-tiles.spec.ts
+++ b/tests/map-tiles.spec.ts
@@ -119,23 +119,29 @@ test.describe("CARTO opportunistic tile cache", () => {
     await expect
       .poll(async () => (await tileUrls(page)).length, { timeout: 30_000 })
       .toBeGreaterThan(0);
-    const urls = await tileUrls(page);
-    // Only genuinely viewed tiles, all matching the narrow rule.
-    expect(urls.length).toBeLessThanOrEqual(300);
-    expect(urls.every((u) => TILE_KEY_RE.test(u))).toBe(true);
-    // Every cached entry is a real CORS response — never opaque.
-    const entryTypes = await page.evaluate(async () => {
+    // Single atomic snapshot: keys + entries together, so tiles cached
+    // between two reads cannot skew the assertions.
+    const entries = await page.evaluate(async () => {
       const cache = await caches.open("metto-carto-tiles");
-      const out: { status: number; type: string }[] = [];
+      const out: { url: string; status: number; type: string }[] = [];
       for (const req of await cache.keys()) {
         const res = await cache.match(req);
-        if (res) out.push({ status: res.status, type: res.type });
+        out.push({
+          url: req.url,
+          status: res ? res.status : -1,
+          type: res ? res.type : "missing",
+        });
       }
       return out;
     });
-    expect(entryTypes.length).toBe(urls.length);
-    expect(entryTypes.every((e) => e.status === 200 && e.type === "cors")).toBe(true);
-    expect(entryTypes.some((e) => e.type === "opaque")).toBe(false);
+    const urls = entries.map((e) => e.url);
+    // Only genuinely viewed tiles, all matching the narrow rule.
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.length).toBeLessThanOrEqual(300);
+    expect(urls.every((u) => TILE_KEY_RE.test(u))).toBe(true);
+    // Every cached entry is a real CORS response — never opaque.
+    expect(entries.every((e) => e.status === 200 && e.type === "cors")).toBe(true);
+    expect(entries.some((e) => e.type === "opaque")).toBe(false);
     expect(await foreignCachedUrls(page)).toEqual([]);
 
     const after = await storageUsage(page);
@@ -160,7 +166,7 @@ test.describe("CARTO opportunistic tile cache", () => {
       offlinePage.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      offlinePage.getByText(/نقشه پایه به اینترنت نیاز دارد/),
+      offlinePage.getByText("بدون اینترنت", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
     // Cached tile returns 200 offline (served by the worker cache).

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -65,12 +65,16 @@ test.describe("Offline bottom navigation", () => {
     // `Next-Router-Prefetch`) — those stay allowed and are excluded here.
     const navRscRequests: string[] = [];
     page.on("request", (req) => {
+      // catch(): header reads reject for requests torn down mid-flight;
+      // an unhandled rejection would fail the test spuriously.
       void Promise.all([
         req.headerValue("rsc"),
         req.headerValue("next-router-prefetch"),
-      ]).then(([rsc, prefetch]) => {
-        if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
-      });
+      ])
+        .then(([rsc, prefetch]) => {
+          if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
+        })
+        .catch(() => {});
     });
 
     await tabLink(page, "نقشه").click();
@@ -84,7 +88,7 @@ test.describe("Offline bottom navigation", () => {
       "/stations",
     );
     await expect(
-      page.getByPlaceholder("جستجوی ایستگاه…"),
+      page.locator('input[placeholder="جستجوی ایستگاه…"]:visible'),
     ).toBeVisible({ timeout: 30_000 });
 
     await tabLink(page, "نزدیک من").click();
@@ -198,12 +202,16 @@ test.describe("Offline bottom navigation", () => {
     });
     const navRscRequests: string[] = [];
     page.on("request", (req) => {
+      // catch(): header reads reject for requests torn down mid-flight;
+      // an unhandled rejection would fail the test spuriously.
       void Promise.all([
         req.headerValue("rsc"),
         req.headerValue("next-router-prefetch"),
-      ]).then(([rsc, prefetch]) => {
-        if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
-      });
+      ])
+        .then(([rsc, prefetch]) => {
+          if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
+        })
+        .catch(() => {});
     });
     await context.setOffline(true);
 
@@ -225,7 +233,7 @@ test.describe("Offline bottom navigation", () => {
     );
     expect(new URL(page.url()).searchParams.get("from")).toBe("tajrish");
     await expect(
-      page.getByPlaceholder("جستجوی ایستگاه…"),
+      page.locator('input[placeholder="جستجوی ایستگاه…"]:visible'),
     ).toBeVisible({ timeout: 30_000 });
 
     // Nearby with query → Nearby HTML.

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Offline bottom-navigation: tapping static tabs while offline must open
+// them via full-document navigation (served from precache), because
+// client-side RSC fetches cannot succeed offline. Uses the mobile
+// viewport so the bottom tab bar (the reported component) is exercised.
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+async function waitForOfflineReady(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect(status).toBeAttached({ timeout: 60_000 });
+  await expect
+    .poll(
+      async () =>
+        status.getAttribute("data-phase").then((p) => p ?? "unknown"),
+      { timeout: 60_000 },
+    )
+    .not.toBe("preparing");
+  const phase = await status.getAttribute("data-phase");
+  expect(["ready", "offline-ready"]).toContain(phase);
+}
+
+/** Route result is visible (arrival stat + line badge). */
+async function expectRouteResult(page: Page) {
+  await expect(page.getByText("رسیدن", { exact: true }).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("خط", { exact: false }).first()).toBeVisible();
+}
+
+async function pathname(page: Page): Promise<string> {
+  return new URL(page.url()).pathname;
+}
+
+/** The mobile bottom tab bar (the reported component). */
+function bottomNav(page: Page) {
+  return page.locator("div.fixed.bottom-0 nav");
+}
+
+function tabLink(page: Page, name: string) {
+  return bottomNav(page).getByRole("link", { name, exact: true });
+}
+
+test.describe("Offline bottom navigation", () => {
+  test("Route → Map → Stations → Nearby → Route all open offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/?from=ahang&to=aliabad", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForOfflineReady(page);
+    await expectRouteResult(page);
+
+    // The Route tab preserves the query in both modes.
+    const routeHref = await tabLink(page, "مسیر").getAttribute("href");
+    expect(routeHref).toContain("from=ahang");
+    expect(routeHref).toContain("to=aliabad");
+
+    await context.setOffline(true);
+
+    // Mechanism guard: offline taps must not issue client-side *navigation*
+    // RSC requests at all (they are what used to abort the transition).
+    // Link prefetch requests also carry `RSC: 1` (plus
+    // `Next-Router-Prefetch`) — those stay allowed and are excluded here.
+    const navRscRequests: string[] = [];
+    page.on("request", (req) => {
+      void Promise.all([
+        req.headerValue("rsc"),
+        req.headerValue("next-router-prefetch"),
+      ]).then(([rsc, prefetch]) => {
+        if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
+      });
+    });
+
+    await tabLink(page, "نقشه").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/map");
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await tabLink(page, "ایستگاه‌ها").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/stations",
+    );
+    await expect(
+      page.getByPlaceholder("جستجوی ایستگاه…"),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await tabLink(page, "نزدیک من").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/nearby",
+    );
+    await expect(
+      page.getByText("موقعیت شما", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Back to Route: same href semantics as online, route state intact.
+    await tabLink(page, "مسیر").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/");
+    expect(new URL(page.url()).searchParams.get("from")).toBe("ahang");
+    expect(new URL(page.url()).searchParams.get("to")).toBe("aliabad");
+    await expectRouteResult(page);
+    // Flush any in-flight header reads, then assert zero navigation RSC.
+    await page.waitForTimeout(1000);
+    expect(navRscRequests).toEqual([]);
+
+    await context.setOffline(false);
+  });
+
+  test("modifier clicks keep normal browser semantics offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForOfflineReady(page);
+    await context.setOffline(true);
+
+    // Ctrl-click must NOT trigger the offline document navigation on this
+    // page: the current tab stays put (the browser handles the new tab).
+    await tabLink(page, "نقشه").click({ modifiers: ["Control"] });
+    await page.waitForTimeout(2000);
+    expect(await pathname(page)).toBe("/");
+    // Clean up any tab the browser opened for the modifier click.
+    for (const p of context.pages()) {
+      if (p !== page) await p.close();
+    }
+
+    await context.setOffline(false);
+  });
+});

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -41,6 +41,43 @@ function tabLink(page: Page, name: string) {
   return bottomNav(page).getByRole("link", { name, exact: true });
 }
 
+const INCOMPLETE_WARNING_FA =
+  "این دستگاه هنوز برای استفاده آفلاین آماده نشده است";
+
+/**
+ * Settle assertion for an offline full-document navigation on an
+ * already-prepared device: the fresh boot must go UNKNOWN (preparing) and
+ * then straight to offline-ready — NEVER through offline-incomplete.
+ * Samples the phase continuously while waiting so a transient flash of the
+ * amber warning state fails the test instead of slipping between polls.
+ */
+async function expectOfflineReadyWithoutIncompleteFlash(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect
+    .poll(
+      async () => {
+        const p =
+          await status.getAttribute("data-phase").then((v) => v ?? "unknown");
+        // Structural guard: unknown-vs-missing. Any intermediate
+        // offline-incomplete on a prepared device is the real-device bug.
+        expect(p).not.toBe("offline-incomplete");
+        return p;
+      },
+      { timeout: 30_000 },
+    )
+    .toBe("offline-ready");
+  // Verified gate actually engaged on this document.
+  expect(
+    await page.evaluate(
+      () =>
+        (window as unknown as { __mettoOffline?: Record<string, unknown> })
+          .__mettoOffline,
+    ),
+  ).toMatchObject({ readinessVerified: true });
+  // And the amber warning never rendered (grace + gate combined).
+  await expect(page.getByText(INCOMPLETE_WARNING_FA)).toHaveCount(0);
+}
+
 test.describe("Offline bottom navigation", () => {
   test("Route → Map → Stations → Nearby → Route all open offline", async ({
     context,
@@ -58,6 +95,15 @@ test.describe("Offline bottom navigation", () => {
     expect(routeHref).toContain("to=aliabad");
 
     await context.setOffline(true);
+
+    // Transition guard: collect every readiness snapshot logged while
+    // offline. No document in this cycle may ever report offline-incomplete.
+    const offlineLogs: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "debug" && msg.text().includes("[Metto Offline]")) {
+        offlineLogs.push(msg.text());
+      }
+    });
 
     // Mechanism guard: offline taps must not issue client-side *navigation*
     // RSC requests at all (they are what used to abort the transition).
@@ -82,6 +128,7 @@ test.describe("Offline bottom navigation", () => {
     await expect(
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
+    await expectOfflineReadyWithoutIncompleteFlash(page);
 
     await tabLink(page, "ایستگاه‌ها").click();
     await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
@@ -90,6 +137,7 @@ test.describe("Offline bottom navigation", () => {
     await expect(
       page.locator('input[placeholder="جستجوی ایستگاه…"]:visible'),
     ).toBeVisible({ timeout: 30_000 });
+    await expectOfflineReadyWithoutIncompleteFlash(page);
 
     await tabLink(page, "نزدیک من").click();
     await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
@@ -98,6 +146,7 @@ test.describe("Offline bottom navigation", () => {
     await expect(
       page.getByText("موقعیت شما", { exact: true }),
     ).toBeVisible({ timeout: 30_000 });
+    await expectOfflineReadyWithoutIncompleteFlash(page);
 
     // Back to Route: same href semantics as online, route state intact.
     await tabLink(page, "مسیر").click();
@@ -105,9 +154,14 @@ test.describe("Offline bottom navigation", () => {
     expect(new URL(page.url()).searchParams.get("from")).toBe("ahang");
     expect(new URL(page.url()).searchParams.get("to")).toBe("aliabad");
     await expectRouteResult(page);
+    await expectOfflineReadyWithoutIncompleteFlash(page);
     // Flush any in-flight header reads, then assert zero navigation RSC.
     await page.waitForTimeout(1000);
     expect(navRscRequests).toEqual([]);
+    // No document in the whole offline cycle ever entered the warning state.
+    expect(
+      offlineLogs.filter((l) => l.includes("offline-incomplete")),
+    ).toEqual([]);
 
     await context.setOffline(false);
   });

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -128,4 +128,138 @@ test.describe("Offline bottom navigation", () => {
 
     await context.setOffline(false);
   });
+
+  test("cold query navigations serve their canonical precached document", async ({
+    context,
+  }) => {
+    // Truly cold: only `/` is ever loaded online. In particular NO
+    // query-bearing document may be warmed into `metto-pages` first.
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForOfflineReady(page);
+
+    // Canonical static documents exist ONLY because of precache…
+    const precachedPaths: string[] = await page.evaluate(async () => {
+      const found = new Set<string>();
+      for (const name of await caches.keys()) {
+        if (!name.includes("precache")) continue;
+        const cache = await caches.open(name);
+        for (const req of await cache.keys()) {
+          found.add(new URL(req.url).pathname);
+        }
+      }
+      return [...found].sort();
+    });
+    for (const p of ["/", "/map", "/stations", "/nearby"]) {
+      expect(precachedPaths).toContain(p);
+    }
+
+    // …while query-specific versions are absent from the runtime cache.
+    const warmedQueryDocs: string[] = await page.evaluate(async () => {
+      const out: string[] = [];
+      try {
+        const cache = await caches.open("metto-pages");
+        for (const req of await cache.keys()) {
+          const u = new URL(req.url);
+          if (u.search.length > 0) out.push(u.pathname + u.search);
+        }
+      } catch {
+        // Cache may not exist yet — equally cold.
+      }
+      return out;
+    });
+    expect(warmedQueryDocs).toEqual([]);
+
+    // Create route context WITHOUT navigating: combobox selection updates
+    // tab hrefs client-side to arbitrary (non-hardcoded) values.
+    await page
+      .getByRole("button", { name: /ایستگاه یا نام مکان/ })
+      .first()
+      .click();
+    await page.locator('input[dir="auto"]').first().fill("تجریش");
+    await page.getByRole("button", { name: /تجریش/ }).first().click();
+    await expect(page).toHaveURL(/from=tajrish/, { timeout: 15_000 });
+    await page
+      .getByRole("button", { name: /ایستگاه یا نام مکان/ })
+      .first()
+      .click();
+    await page.locator('input[dir="auto"]').first().fill("تهران (صادقیه)");
+    await page.getByRole("button", { name: /تهران/ }).first().click();
+    const mapHref =
+      (await tabLink(page, "نقشه").getAttribute("href")) ?? "";
+    expect(mapHref).toContain("from=tajrish");
+    expect(mapHref).toContain("to=tehran-sadeghiyeh");
+    await expectRouteResult(page);
+
+    // Offline from here on. Track fatal document failures + RSC fallback.
+    const failedDocs: string[] = [];
+    page.on("requestfailed", (req) => {
+      if (req.resourceType() === "document") failedDocs.push(req.url());
+    });
+    const navRscRequests: string[] = [];
+    page.on("request", (req) => {
+      void Promise.all([
+        req.headerValue("rsc"),
+        req.headerValue("next-router-prefetch"),
+      ]).then(([rsc, prefetch]) => {
+        if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
+      });
+    });
+    await context.setOffline(true);
+
+    // Map with query → Map HTML (never Route HTML), query intact.
+    await tabLink(page, "نقشه").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/map");
+    expect(new URL(page.url()).searchParams.get("from")).toBe("tajrish");
+    expect(new URL(page.url()).searchParams.get("to")).toBe(
+      "tehran-sadeghiyeh",
+    );
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Stations with query → Stations HTML.
+    await tabLink(page, "ایستگاه‌ها").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/stations",
+    );
+    expect(new URL(page.url()).searchParams.get("from")).toBe("tajrish");
+    await expect(
+      page.getByPlaceholder("جستجوی ایستگاه…"),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Nearby with query → Nearby HTML.
+    await tabLink(page, "نزدیک من").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/nearby",
+    );
+    expect(new URL(page.url()).searchParams.get("to")).toBe(
+      "tehran-sadeghiyeh",
+    );
+    await expect(
+      page.getByText("موقعیت شما", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Route with query → Route HTML.
+    await tabLink(page, "مسیر").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/");
+    await expectRouteResult(page);
+
+    // Cold arbitrary combo incl. junk param → canonical Nearby HTML,
+    // full requested URL preserved.
+    await page.goto(
+      "/nearby?from=tajrish&to=tehran-sadeghiyeh&x=1",
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(
+      page.getByText("موقعیت شما", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+    expect(page.url()).toContain("x=1");
+
+    await page.waitForTimeout(1000);
+    expect(failedDocs).toEqual([]);
+    expect(navRscRequests).toEqual([]);
+
+    await context.setOffline(false);
+  });
 });

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -284,23 +284,29 @@ test.describe("Metto offline PWA", () => {
 
       // Old clients disappear → the waiting worker activates naturally, and
       // the next launch is controlled by it. No SKIP_WAITING, no reload loop.
-      // Generous timeout: activation competes with parallel suite load.
+      // If the fresh navigation wins the race and lands on the old worker,
+      // it blocks activation itself — reloading retries the navigation at a
+      // moment with zero controlled clients, which is also exactly how a
+      // real user launch behaves.
       await page.close();
       const page2 = await context.newPage();
       await page2.goto("/", { waitUntil: "domcontentloaded" });
-      await expect
-        .poll(
-          async () =>
-            page2.evaluate(async () => {
-              const reg = await navigator.serviceWorker.getRegistration();
-              return {
-                controlled: !!navigator.serviceWorker.controller,
-                waiting: !!reg?.waiting,
-              };
-            }),
-          { timeout: 60_000 },
-        )
-        .toEqual({ controlled: true, waiting: false });
+      let settled = false;
+      for (let i = 0; i < 6 && !settled; i++) {
+        const s = await page2.evaluate(async () => {
+          const reg = await navigator.serviceWorker.getRegistration();
+          return {
+            controlled: !!navigator.serviceWorker.controller,
+            waiting: !!reg?.waiting,
+          };
+        });
+        settled = s.controlled && !s.waiting;
+        if (!settled) {
+          await page2.reload({ waitUntil: "domcontentloaded" });
+          await page2.waitForTimeout(2000);
+        }
+      }
+      expect(settled).toBe(true);
       await waitForOfflineReady(page2);
     } finally {
       fs.writeFileSync(swPath, originalSw);

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -153,8 +153,11 @@ test.describe("Metto offline PWA", () => {
     await expect(page.getByText("شما آفلاین هستید")).toHaveCount(0);
 
     // 12-13. Station search works offline (stations page, direct load).
+    // :visible because Next may briefly retain a hidden transition copy.
     await page.goto("/stations", { waitUntil: "domcontentloaded" });
-    const stationSearch = page.getByPlaceholder("جستجوی ایستگاه…");
+    const stationSearch = page.locator(
+      'input[placeholder="جستجوی ایستگاه…"]:visible',
+    );
     await expect(stationSearch).toBeVisible({ timeout: 30_000 });
     await stationSearch.fill(ORIGIN_FA);
     await expect(
@@ -199,7 +202,9 @@ test.describe("Metto offline PWA", () => {
     // 21-23. Holiday info renders offline from the local dataset via the
     // existing timetable UI; routing made zero upstream holiday calls.
     await page.goto("/stations", { waitUntil: "domcontentloaded" });
-    await page.getByPlaceholder("جستجوی ایستگاه…").fill(ORIGIN_FA);
+    await page
+      .locator('input[placeholder="جستجوی ایستگاه…"]:visible')
+      .fill(ORIGIN_FA);
     await page.getByRole("button", { name: /برنامه/ }).first().click();
     await expect(page.getByText("تعطیلات رسمی").first()).toBeVisible({
       timeout: 15_000,

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -225,6 +225,59 @@ test.describe("Metto offline PWA", () => {
     );
   });
 
+  test("map overlay cards never overlap, online or offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    const pinsUrl =
+      `/map?from=${ORIGIN_ID}&to=${DEST_ID}` +
+      `&op=35.7448,51.3755,مبدأ تست` +
+      `&dp=35.7000,51.4000,مقصد تست`;
+    await page.goto(pinsUrl, { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    async function assertStackedTopToBottom() {
+      // Every visible card in the top stack must sit fully below the
+      // previous one (2px tolerance for subpixel rounding).
+      const boxes: Array<{ y: number; height: number }> = [];
+      for (const testid of ["map-offline-banner", "map-place-card"]) {
+        const loc = page.getByTestId(testid);
+        const count = await loc.count();
+        for (let i = 0; i < count; i++) {
+          const box = await loc.nth(i).boundingBox();
+          // Only consider actually rendered cards.
+          if (box && box.height > 0) boxes.push(box);
+        }
+      }
+      // Order top-to-bottom as they appear in the stack.
+      boxes.sort((a, b) => a.y - b.y);
+      expect(boxes.length).toBeGreaterThanOrEqual(2);
+      for (let i = 1; i < boxes.length; i++) {
+        expect(boxes[i].y).toBeGreaterThanOrEqual(
+          boxes[i - 1].y + boxes[i - 1].height - 2,
+        );
+      }
+    }
+
+    // Online: save notice + 2 place cards stacked without overlap.
+    await expect(page.getByTestId("map-place-card")).toHaveCount(2, {
+      timeout: 15_000,
+    });
+    await assertStackedTopToBottom();
+
+    // Offline: banner replaces the notice; banner + 2 cards still stacked.
+    await context.setOffline(true);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("map-offline-banner")).toBeVisible();
+    await expect(page.getByTestId("map-place-card")).toHaveCount(2);
+    await assertStackedTopToBottom();
+    await context.setOffline(false);
+  });
+
   test("waiting worker stays silent, never reloads, activates naturally", async ({
     context,
   }) => {

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -177,7 +177,7 @@ test.describe("Metto offline PWA", () => {
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      page.getByText(/نقشه پایه به اینترنت نیاز دارد/),
+      page.getByText("بدون اینترنت", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
     // 18-20. Landmark search explains the Internet requirement offline.
@@ -284,6 +284,7 @@ test.describe("Metto offline PWA", () => {
 
       // Old clients disappear → the waiting worker activates naturally, and
       // the next launch is controlled by it. No SKIP_WAITING, no reload loop.
+      // Generous timeout: activation competes with parallel suite load.
       await page.close();
       const page2 = await context.newPage();
       await page2.goto("/", { waitUntil: "domcontentloaded" });
@@ -297,7 +298,7 @@ test.describe("Metto offline PWA", () => {
                 waiting: !!reg?.waiting,
               };
             }),
-          { timeout: 30_000 },
+          { timeout: 60_000 },
         )
         .toEqual({ controlled: true, waiting: false });
       await waitForOfflineReady(page2);


### PR DESCRIPTION
Stacked on #29 (PWA work). Narrow bugfix only — no SW redesign, no CARTO-cache changes, no routing/timetable/holiday/manifest changes.

## Confirmed causes
- **A. No recovery after reconnect:** `RealMap` creates tile layers once and only touches them on `mapMode` change. Leaflet retains failed tiles until the view changes, and nothing listened for `online` — so uncached tiles that failed offline sat dead until zoom/pan.
- **B. Inconsistent banner:** derived from `navigator.onLine` read once at mount + online/offline events only. A suspended PWA resumed after a connectivity change can hold stale state; tile-error state was (correctly) never consulted.
- **C. Bottom-nav tap fails offline:** plain Next `<Link>` transitions issue RSC/Flight requests; the SW correctly refuses to fake RSC (NetworkFirst, no offline fallback), Next aborts the transition, user stays on `/`. Prefetch measured harmless (navigation-RSC count is zero with the fix; prefetch stays enabled).

## Changes
- `lib/offline/use-connectivity.ts` (new): shared hook (mount + online/offline + pageshow + visible visibilitychange) + pure `isPrecachedTabUrl` / `shouldInterceptOfflineNav` helpers.
- `components/real-map.tsx`: `redraw()` attached basemap layers (CARTO minimalist + active Esri layers, no caching change) on false→true transitions only; initial online mount excluded via prev-state ref.
- `app/map/client.tsx` + `lib/i18n.ts`: deterministic offline banner (exact Title/Body copy, fa/en) shown iff offline; one-time save notice (exact copy, info styling, localStorage `metto.mapSaveNoticeSeen`, never stacked with offline banner); removed now-unused `mapOfflineNote`.
- `app/nav.tsx`: shared `TabLink` (desktop tabs, mobile bottom bar, logo) — offline plain primary clicks on the 4 precached tabs use `window.location.assign`; Ctrl/Cmd/Shift/Alt/middle-click, targets, and non-precached URLs untouched.
- Route state: unchanged semantics — tab hrefs already carry `?from=&to=` from context and home page restores from URL/localStorage; verified by E2E.
- `playwright.config.ts`: `workers: 1` (offline suite mutates shared server state; parallelism caused flakes) + fixed a cache-read TOCTOU in map-tiles.spec.
- Docs: manual PWA checklist extended (reconnect/nav/background steps).

## Tests
- New: `tests/map-reconnect.spec.ts` (3 tests), `tests/offline-nav.spec.ts` (2 tests, mobile viewport), unit tests for helpers + notice copy.
- `tsc` clean · `vitest` 11 files / 138 pass · `pnpm build` OK (46 precached URLs) · Playwright **10 passed**.
- Live servers never contacted (mocked CARTO PNGs, blocked third parties).