### PR TITLE
Fix overlapping map overlay cards

### DIFF
--- a/app/map/client.tsx
+++ b/app/map/client.tsx
@@ -7,6 +7,7 @@ import { Loader2, Layers, Satellite, Building2, AlertTriangle, X, WifiOff } from
 import { useMetro } from "@/app/providers";
 import { STATION_MAP, findRoute } from "@/lib/route";
 import { useHolidayData } from "@/lib/holidays/use-holiday-data";
+import { useConnectivity } from "@/lib/offline/use-connectivity";
 import { STRINGS } from "@/lib/i18n";
 import {
   haversineKm,
@@ -108,20 +109,41 @@ export function MapPage() {
 
   const [selectedId, setSelectedId] = useState<string | null>(initialParams.station);
   const [dismissedKeys, setDismissedKeys] = useState<ReadonlySet<string>>(new Set());
-  const [isOffline, setIsOffline] = useState(
-    () => typeof navigator !== "undefined" && navigator.onLine === false,
-  );
+  // Shared connectivity state (mount + online/offline + pageshow +
+  // foreground resync), so the banner reflects real network state even
+  // after the PWA resumes from background — never tile-error state.
+  const online = useConnectivity();
+  const isOffline = !online;
 
+  // One-time informational save notice: shown once per device while online,
+  // remembered locally. Never stacked with the offline banner, never a
+  // warning, no retention promises or implementation details.
+  const [saveNoticeSeen, setSaveNoticeSeen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem("metto.mapSaveNoticeSeen") === "1";
+    } catch {
+      return true;
+    }
+  });
+  const [saveNoticeDismissed, setSaveNoticeDismissed] = useState(false);
   useEffect(() => {
-    const onOnline = () => setIsOffline(false);
-    const onOffline = () => setIsOffline(true);
-    window.addEventListener("online", onOnline);
-    window.addEventListener("offline", onOffline);
-    return () => {
-      window.removeEventListener("online", onOnline);
-      window.removeEventListener("offline", onOffline);
-    };
-  }, []);
+    if (online && !saveNoticeSeen) {
+      try {
+        localStorage.setItem("metto.mapSaveNoticeSeen", "1");
+      } catch {
+        // Private mode etc. — notice simply shows again next visit.
+      }
+    }
+  }, [online, saveNoticeSeen]);
+  const showSaveNotice = online && !saveNoticeSeen && !saveNoticeDismissed;
+  function dismissSaveNotice() {
+    setSaveNoticeDismissed(true);
+    try {
+      localStorage.setItem("metto.mapSaveNoticeSeen", "1");
+    } catch {
+      // Ignore.
+    }
+  }
 
   // A dismissed card stays dismissed for this search; a new search (URL change) brings cards back.
   useEffect(() => {
@@ -158,13 +180,36 @@ export function MapPage() {
         placeMarkers={placeMarkers}
       />
 
-      {/* Offline basemap notice: vectors still render, tiles need Internet. */}
+      {/* Offline notice: purely connectivity-driven (never tile-error
+          state), so it shows even when cached tiles render fine, hides on
+          reconnect, and never flickers per tile. */}
       {isOffline && (
         <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur">
           <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <p className="min-w-0 flex-1 text-muted-foreground">
-            {t.mapOfflineNote}
-          </p>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
+            <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
+          </div>
+        </div>
+      )}
+
+      {/* One-time save notice: informational only, online only, never
+          stacked with the offline banner. */}
+      {showSaveNotice && (
+        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
+          <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
+            <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
+          </div>
+          <button
+            type="button"
+            onClick={dismissSaveNotice}
+            aria-label={t.close}
+            className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
         </div>
       )}
 

--- a/app/map/client.tsx
+++ b/app/map/client.tsx
@@ -180,88 +180,87 @@ export function MapPage() {
         placeMarkers={placeMarkers}
       />
 
-      {/* Offline notice: purely connectivity-driven (never tile-error
-          state), so it shows even when cached tiles render fine, hides on
-          reconnect, and never flickers per tile. */}
-      {isOffline && (
-        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur">
-          <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
-            <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
+      {/* Top overlay stack: banner/notice/place cards lay out in normal
+          flow inside ONE absolute container, so variable card heights
+          (fa/en copy, font size, screen width) can never overlap. */}
+      <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md flex-col gap-1.5">
+        {/* Offline notice: purely connectivity-driven (never tile-error
+            state), so it shows even when cached tiles render fine, hides on
+            reconnect, and never flickers per tile. */}
+        {isOffline && (
+          <div
+            data-testid="map-offline-banner"
+            className="flex items-start gap-2 rounded-lg border border-border bg-background/95 px-3 py-2 text-xs shadow-sm backdrop-blur">
+            <WifiOff className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-foreground">{t.mapOfflineTitle}</p>
+              <p className="mt-0.5 text-muted-foreground">{t.mapOfflineBody}</p>
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* One-time save notice: informational only, online only, never
-          stacked with the offline banner. */}
-      {showSaveNotice && (
-        <div className="absolute inset-x-3 top-14 z-[500] mx-auto flex max-w-md items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
-          <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
-          <div className="min-w-0 flex-1">
-            <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
-            <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
-          </div>
-          <button
-            type="button"
-            onClick={dismissSaveNotice}
-            aria-label={t.close}
-            className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            <X className="size-3.5" />
-          </button>
-        </div>
-      )}
-
-      {visiblePlaceInfos.length > 0 && (
-        <div
-          className={cn(
-            "absolute inset-x-3 z-[500] mx-auto flex max-w-md flex-col gap-1.5",
-            isOffline ? "top-28" : "top-14",
-          )}
-        >
-          {visiblePlaceInfos.map((p) => (
-            <div
-              key={`${p.role}:${p.label}`}
-              className={cn(
-                "flex items-start gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm backdrop-blur",
-                p.tooFar
-                  ? "border-amber-500/40 bg-background/95 text-foreground"
-                  : "border-border bg-background/90 text-foreground",
-              )}
+        {/* One-time save notice: informational only, online only, never
+            stacked with the offline banner. */}
+        {showSaveNotice && (
+          <div className="flex items-start gap-2 rounded-lg border border-border bg-background/90 px-3 py-2 text-xs shadow-sm backdrop-blur">
+            <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-foreground">{t.mapSaveTitle}</p>
+              <p className="mt-0.5 text-muted-foreground">{t.mapSaveBody}</p>
+            </div>
+            <button
+              type="button"
+              onClick={dismissSaveNotice}
+              aria-label={t.close}
+              className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
-              {p.tooFar ? (
-                <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
-              ) : (
-                <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
-              )}
-              <div className="min-w-0 flex-1">
-                <p className="truncate font-medium">{p.label}</p>
-                <p className="mt-0.5 text-muted-foreground">
-                  {t.nearestStation}: {p.stationName} · {p.distanceText} · ~{p.walkText} {t.walkTime}
+              <X className="size-3.5" />
+            </button>
+          </div>
+        )}
+
+        {visiblePlaceInfos.map((p) => (
+          <div
+            key={`${p.role}:${p.label}`}
+            data-testid="map-place-card"
+            className={cn(
+              "flex items-start gap-2 rounded-lg border px-3 py-2 text-xs shadow-sm backdrop-blur",
+              p.tooFar
+                ? "border-amber-500/40 bg-background/95 text-foreground"
+                : "border-border bg-background/90 text-foreground",
+            )}
+          >
+            {p.tooFar ? (
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-500" />
+            ) : (
+              <Building2 className="mt-0.5 size-4 shrink-0 text-primary" />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium">{p.label}</p>
+              <p className="mt-0.5 text-muted-foreground">
+                {t.nearestStation}: {p.stationName} · {p.distanceText} · ~{p.walkText} {t.walkTime}
+              </p>
+              {p.tooFar && (
+                <p className="mt-0.5 font-medium text-amber-600 dark:text-amber-400">
+                  {t.tooFarFromStation} (~{p.walkText})
                 </p>
-                {p.tooFar && (
-                  <p className="mt-0.5 font-medium text-amber-600 dark:text-amber-400">
-                    {t.tooFarFromStation} (~{p.walkText})
-                  </p>
-                )}
-              </div>
-              {ENABLE_PLACE_CARD_DISMISS && (
-              <button
-                type="button"
-                onClick={() =>
-                  setDismissedKeys((prev) => new Set(prev).add(`${p.role}:${p.label}`))
-                }
-                aria-label={t.close}
-                className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <X className="size-3.5" />
-              </button>
               )}
             </div>
-          ))}
-        </div>
-      )}
+            {ENABLE_PLACE_CARD_DISMISS && (
+            <button
+              type="button"
+              onClick={() =>
+                setDismissedKeys((prev) => new Set(prev).add(`${p.role}:${p.label}`))
+              }
+              aria-label={t.close}
+              className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </button>
+            )}
+          </div>
+        ))}
+      </div>
 
       {/* Map mode toggle */}
       <div className="absolute top-3 left-3 z-[500] flex overflow-hidden rounded-lg border border-border bg-background/90 shadow-sm backdrop-blur">

--- a/app/nav.tsx
+++ b/app/nav.tsx
@@ -17,6 +17,7 @@ import { OfflineStatus } from "@/components/offline-status";
 import { useMetro } from "./providers";
 import { STRINGS } from "@/lib/i18n";
 import { buildTabHref } from "@/lib/geo";
+import { isPrecachedTabUrl, shouldInterceptOfflineNav, useConnectivity } from "@/lib/offline/use-connectivity";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
@@ -26,10 +27,63 @@ const NAV_ITEMS = [
   { href: "/map", labelKey: "tabMap" as const, icon: MapIcon },
 ] as const;
 
+/**
+ * Top-level tab link. Online it behaves exactly like Next <Link> (client
+ * navigation + prefetch). Offline, plain primary clicks on the four
+ * precached static tabs use a native full-document navigation instead:
+ * client-side RSC fetches cannot succeed offline and would abort the
+ * transition, while a document request is served from the Serwist
+ * precache. Modifier/middle clicks, new-tab targets and non-precached
+ * URLs keep normal browser semantics.
+ */
+function TabLink({
+  href,
+  online,
+  className,
+  ariaCurrent,
+  children,
+}: {
+  href: string;
+  online: boolean;
+  className?: string;
+  ariaCurrent?: "page";
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-current={ariaCurrent}
+      onClick={(e) => {
+        if (online || e.defaultPrevented) return;
+        if (
+          !shouldInterceptOfflineNav({
+            button: e.button,
+            ctrlKey: e.ctrlKey,
+            metaKey: e.metaKey,
+            shiftKey: e.shiftKey,
+            altKey: e.altKey,
+            target: (e.currentTarget as HTMLAnchorElement).target,
+          })
+        ) {
+          return;
+        }
+        if (!isPrecachedTabUrl(href)) return;
+        e.preventDefault();
+        window.location.assign(href);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
 export function AppNav() {
   const { lang, setLang, originId, destId, originPlace, destPlace } = useMetro();
   const pathname = usePathname();
   const t = STRINGS[lang];
+  // One shared subscription for every tab link below.
+  const online = useConnectivity();
 
   const currentPath = pathname === "/" ? "/" : pathname;
   const isMainTab = currentPath === "/";
@@ -53,7 +107,7 @@ export function AppNav() {
   return (
     <>
       <header className="z-20 flex items-center justify-between gap-3 border-b border-border bg-card/80 px-4 py-3 backdrop-blur md:px-6 md:py-4">
-        <Link href="/" className="flex items-center gap-2.5 md:gap-3">
+          <TabLink href="/" online={online} className="flex items-center gap-2.5 md:gap-3">
           <span className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground md:size-10">
             <TrainFront className="size-5 md:size-6" />
           </span>
@@ -61,7 +115,7 @@ export function AppNav() {
             <h1 className="text-base font-bold md:text-lg">{t.appTitle}</h1>
             <p className="text-xs text-muted-foreground md:text-sm">{t.appSubtitle}</p>
           </div>
-        </Link>
+        </TabLink>
 
         {/* desktop tabs */}
         <nav className="hidden items-center gap-1 md:flex">
@@ -69,9 +123,10 @@ export function AppNav() {
             const href = getHref(item.href);
             const active = currentPath === item.href;
             return (
-              <Link
+              <TabLink
                 key={item.href}
                 href={href}
+                online={online}
                 className={cn(
                   "flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors md:gap-2 md:px-4 md:py-2.5 md:text-base",
                   active
@@ -81,7 +136,7 @@ export function AppNav() {
               >
                 <item.icon className="size-5" />
                 {t[item.labelKey]}
-              </Link>
+              </TabLink>
             );
           })}
         </nav>
@@ -142,18 +197,19 @@ export function AppNav() {
             const href = getHref(item.href);
             const active = currentPath === item.href;
             return (
-              <Link
+              <TabLink
                 key={item.href}
                 href={href}
+                online={online}
                 className={cn(
                   "flex flex-col items-center gap-1 py-2.5 text-xs font-medium transition-colors",
                   active ? "text-primary" : "text-muted-foreground",
                 )}
-                aria-current={active ? "page" : undefined}
+                ariaCurrent={active ? "page" : undefined}
               >
                 <item.icon className="size-5" />
                 {t[item.labelKey]}
-              </Link>
+              </TabLink>
             );
           })}
         </nav>

--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -21,6 +21,7 @@ import {
 import type { MetroStation } from "@/lib/metro/types";
 import { STATION_MAP, type RouteResult } from "@/lib/route"
 import { type Lang } from "@/lib/i18n"
+import { useConnectivity } from "@/lib/offline/use-connectivity"
 import { cn } from "@/lib/utils"
 
 type Props = {
@@ -151,6 +152,10 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
   const [locating, setLocating] = useState(false)
   const [gpsError, setGpsError] = useState<string | null>(null)
   const isFa = lang === "fa"
+  const online = useConnectivity()
+  // Tracks the previous connectivity value so only a real offline → online
+  // transition triggers a retry — an initial online mount is not one.
+  const wasOnlineRef = useRef(online)
 
   const edges = useMemo(() => buildMapEdges(), [])
   const routeStations = useMemo(() => new Set(route?.path ?? []), [route])
@@ -466,6 +471,22 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
       container.style.backgroundColor = ""
     }
   }, [mapMode])
+
+  // Retry the active basemap layer(s) when connectivity returns, so tiles
+  // that failed while offline start loading without any zoom/pan gesture.
+  // Runs only on a real offline → online transition: the effect fires when
+  // the boolean flips, and repeated `online` events while already online
+  // change no state. No remount, no view reset, no overlay or cache touch.
+  useEffect(() => {
+    const wasOnline = wasOnlineRef.current
+    wasOnlineRef.current = online
+    if (!online || wasOnline) return
+    const map = mapRef.current
+    if (!map) return
+    for (const layer of [tileLayerRef.current, minimalistLayerRef.current, labelsLayerRef.current]) {
+      if (layer && map.hasLayer(layer)) layer.redraw()
+    }
+  }, [online])
 
   // Redraw overlay whenever the route/selection changes.
   useEffect(() => {

--- a/docs/TWA_READINESS.md
+++ b/docs/TWA_READINESS.md
@@ -310,6 +310,32 @@ restore network
 verify recovery + update banner behavior if a deploy happened
 ```
 
+Map reconnect + offline tabs (also on real Android Chrome / installed PWA):
+
+```text
+install/open Metto online
+↓
+open Map (note the one-time save notice on first visit)
+↓
+go offline
+↓
+pan into an uncached area (blank tiles, offline banner "بدون اینترنت")
+↓
+put the PWA in background
+↓
+restore Internet
+↓
+reopen the PWA (no zoom/pan)
+↓
+missing visible tiles begin loading on their own; banner clears
+↓
+toggle offline again
+↓
+tap Route/Map/Stations/Nearby repeatedly (from /?from=…&to=… too)
+↓
+every static tab opens offline with route state intact
+```
+
 Automated equivalent: `pnpm build && pnpm test:e2e:offline`
 (Playwright, production server, real browser offline mode, mocked Tehran
 geolocation `35.6892, 51.3890`; Nominatim/CARTO/Esri/upstream-holiday

--- a/i18n.test.ts
+++ b/i18n.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { persianDigits } from "./lib/i18n";
+import { persianDigits, STRINGS } from "./lib/i18n";
 
 describe("persianDigits locale behavior", () => {
   it('converts Latin digits to Persian in fa UI ("15:11" -> "۱۵:۱۱")', () => {
@@ -8,5 +8,18 @@ describe("persianDigits locale behavior", () => {
 
   it('keeps Latin digits in en UI ("15:11" stays "15:11")', () => {
     expect(persianDigits("15:11", "en")).toBe("15:11");
+  });
+});
+
+describe("map offline/save notice copy", () => {
+  it("exists in both languages with the exact approved wording", () => {
+    expect(STRINGS.fa.mapOfflineTitle).toBe("بدون اینترنت");
+    expect(STRINGS.en.mapOfflineTitle).toBe("You're offline");
+    expect(STRINGS.fa.mapOfflineBody).toContain("قبلاً دیده‌اید");
+    expect(STRINGS.en.mapOfflineBody).toContain("viewed before");
+    expect(STRINGS.fa.mapSaveTitle).toBe("ذخیره برای استفاده آفلاین");
+    expect(STRINGS.en.mapSaveTitle).toBe("Saved for offline use");
+    expect(STRINGS.fa.mapSaveBody).not.toMatch(/کش|tile/i);
+    expect(STRINGS.en.mapSaveBody).not.toMatch(/cache|tile|service worker/i);
   });
 });

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -79,8 +79,12 @@ export const STRINGS = {
     placeSearchOffline: "Internet is required to search for places.",
     offlineNotPrepared:
       "Offline data hasn't finished downloading on this device. Connect to the Internet once to prepare Metto for offline use.",
-    mapOfflineNote:
-      "The basemap requires Internet; metro lines and stations are still available offline.",
+    mapOfflineTitle: "You're offline",
+    mapOfflineBody:
+      "Areas you've viewed before may still be available. Connect to the internet to load new areas of the map.",
+    mapSaveTitle: "Saved for offline use",
+    mapSaveBody:
+      "Areas of the map you view are saved for use without an internet connection. The entire map is not available offline.",
     holidaysTitle: "Official holidays",
     holidayLastUpdate: "Last update",
     upcomingHolidays: "Upcoming holidays",
@@ -194,8 +198,12 @@ export const STRINGS = {
     placeSearchOffline: "برای جستجوی مکان به اینترنت نیاز است.",
     offlineNotPrepared:
       "این دستگاه هنوز برای استفاده آفلاین آماده نشده است. برای دریافت اطلاعات لازم یک‌بار به اینترنت متصل شوید.",
-    mapOfflineNote:
-      "نقشه پایه به اینترنت نیاز دارد؛ خطوط و ایستگاه‌های مترو آفلاین نمایش داده می‌شوند.",
+    mapOfflineTitle: "بدون اینترنت",
+    mapOfflineBody:
+      "بخش‌هایی از نقشه که قبلاً دیده‌اید همچنان در دسترس‌اند. برای دیدن بخش‌های جدید نقشه به اینترنت نیاز دارید.",
+    mapSaveTitle: "ذخیره برای استفاده آفلاین",
+    mapSaveBody:
+      "بخش‌هایی از نقشه که می‌بینید، برای استفاده بدون اینترنت ذخیره می‌شوند. همهٔ نقشه آفلاین نیست.",
     holidaysTitle: "تعطیلات رسمی",
     holidayLastUpdate: "آخرین بروزرسانی",
     upcomingHolidays: "تعطیلات پیش‌رو",

--- a/lib/offline/use-connectivity.test.ts
+++ b/lib/offline/use-connectivity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { isPrecachedTabUrl, shouldInterceptOfflineNav } from "./use-connectivity";
+
+describe("isPrecachedTabUrl", () => {
+  it("matches the four precached static tabs", () => {
+    expect(isPrecachedTabUrl("/")).toBe(true);
+    expect(isPrecachedTabUrl("/stations")).toBe(true);
+    expect(isPrecachedTabUrl("/nearby")).toBe(true);
+    expect(isPrecachedTabUrl("/map")).toBe(true);
+  });
+
+  it("ignores query strings and hashes (route state is preserved)", () => {
+    expect(isPrecachedTabUrl("/?from=ahang&to=aliabad")).toBe(true);
+    expect(isPrecachedTabUrl("/map?from=ahang")).toBe(true);
+    expect(isPrecachedTabUrl("/stations#list")).toBe(true);
+  });
+
+  it("rejects dynamic, API, and external URLs", () => {
+    expect(isPrecachedTabUrl("/api/route")).toBe(false);
+    expect(isPrecachedTabUrl("/stations/123")).toBe(false);
+    expect(isPrecachedTabUrl("/map/extra/path")).toBe(false);
+    expect(isPrecachedTabUrl("https://metto.ir/map")).toBe(false);
+    expect(isPrecachedTabUrl("https://github.com/aliinreallife")).toBe(false);
+    expect(isPrecachedTabUrl("")).toBe(false);
+    expect(isPrecachedTabUrl("/MAP")).toBe(false);
+  });
+});
+
+describe("shouldInterceptOfflineNav", () => {
+  const plain = {
+    button: 0,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+  };
+
+  it("allows an ordinary same-tab primary click", () => {
+    expect(shouldInterceptOfflineNav(plain)).toBe(true);
+    expect(shouldInterceptOfflineNav({ ...plain, target: "_self" })).toBe(true);
+    expect(shouldInterceptOfflineNav({ ...plain, target: null })).toBe(true);
+  });
+
+  it("never intercepts modifier, middle-click, or new-tab navigation", () => {
+    expect(shouldInterceptOfflineNav({ ...plain, button: 1 })).toBe(false);
+    expect(shouldInterceptOfflineNav({ ...plain, button: 2 })).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, ctrlKey: true }),
+    ).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, metaKey: true }),
+    ).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, shiftKey: true }),
+    ).toBe(false);
+    expect(shouldInterceptOfflineNav({ ...plain, altKey: true })).toBe(false);
+    expect(
+      shouldInterceptOfflineNav({ ...plain, target: "_blank" }),
+    ).toBe(false);
+  });
+});

--- a/lib/offline/use-connectivity.ts
+++ b/lib/offline/use-connectivity.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Single reliable client-side connectivity source for the whole app.
+ *
+ * Based primarily on `navigator.onLine`, resynchronized on:
+ * - initial client mount,
+ * - `window` online / offline events,
+ * - `pageshow` (back/forward cache restores, PWA resume),
+ * - `visibilitychange` when the document becomes visible again
+ *   (an installed PWA may have slept through a connectivity change).
+ *
+ * Deliberately NOT derived from tile/API failures: a CARTO CDN failure
+ * while `navigator.onLine === true` must never mark the device offline.
+ */
+export function useConnectivity(): boolean {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator === "undefined" ? true : navigator.onLine !== false,
+  );
+
+  useEffect(() => {
+    const sync = () => {
+      try {
+        setOnline(navigator.onLine !== false);
+      } catch {
+        // Keep the last known value if unreadable.
+      }
+    };
+    // Align immediately on mount in case connectivity changed while
+    // suspended/backgrounded before this component mounted.
+    sync();
+    const onVisibility = () => {
+      if (!document.hidden) sync();
+    };
+    window.addEventListener("online", sync);
+    window.addEventListener("offline", sync);
+    window.addEventListener("pageshow", sync);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("online", sync);
+      window.removeEventListener("offline", sync);
+      window.removeEventListener("pageshow", sync);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+
+  return online;
+}
+
+/** Top-level static tabs known to be in the Serwist precache. */
+const PRECACHED_TABS: ReadonlySet<string> = new Set([
+  "/",
+  "/stations",
+  "/nearby",
+  "/map",
+]);
+
+/**
+ * True for the top-level static tab URLs that are guaranteed precached,
+ * so an offline full-document navigation to them is safe. Query strings
+ * are ignored (`/?from=…` maps to `/`); dynamic/API/external URLs are
+ * never matched.
+ */
+export function isPrecachedTabUrl(href: string): boolean {
+  if (!href.startsWith("/")) return false;
+  const pathname = href.split("?", 1)[0].split("#", 1)[0] || "/";
+  return PRECACHED_TABS.has(pathname);
+}
+
+export interface PrimaryClickShape {
+  button: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  target?: string | null;
+}
+
+/**
+ * True only for an ordinary same-tab primary-button navigation — the one
+ * case where offline tab links fall back to `window.location.assign`.
+ * Modifier/middle clicks, new-tab targets and anything else keep normal
+ * browser link semantics and are never intercepted.
+ */
+export function shouldInterceptOfflineNav(e: PrimaryClickShape): boolean {
+  if (e.button !== 0) return false;
+  if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return false;
+  if (e.target && e.target !== "_self") return false;
+  return true;
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts",
+    "test:e2e:offline": "playwright test tests/offline.spec.ts tests/map-tiles.spec.ts tests/map-reconnect.spec.ts tests/offline-nav.spec.ts",
     "holidays:sync": "node scripts/sync-holidays.mjs",
     "generate:stations": "node scripts/generate-stations.ts"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   timeout: 120_000,
   expect: { timeout: 20_000 },
   fullyParallel: false,
+  // Serial: offline tests mutate shared server state (one spec rewrites
+  // public/sw.js to simulate a release) and assert timing-sensitive SW
+  // cache contents; parallelism makes both flaky.
+  workers: 1,
   retries: 0,
   reporter: "list",
   use: {

--- a/tests/map-reconnect.spec.ts
+++ b/tests/map-reconnect.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
+
+// Map recovery + deterministic offline banner. Mocked CARTO tiles only,
+// no live servers.
+const PNG_1PX = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+async function waitForOfflineReady(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect(status).toBeAttached({ timeout: 60_000 });
+  await expect
+    .poll(
+      async () =>
+        status.getAttribute("data-phase").then((p) => p ?? "unknown"),
+      { timeout: 60_000 },
+    )
+    .not.toBe("preparing");
+  const phase = await status.getAttribute("data-phase");
+  expect(["ready", "offline-ready"]).toContain(phase);
+}
+
+async function cachedTileCount(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    try {
+      const cache = await caches.open("metto-carto-tiles");
+      return (await cache.keys()).length;
+    } catch {
+      return 0;
+    }
+  });
+}
+
+test.describe("Map reconnect recovery", () => {
+  test.beforeEach(async ({ context }: { context: BrowserContext }) => {
+    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: PNG_1PX,
+      }),
+    );
+  });
+
+  test("missing tiles reload on reconnect without pan, zoom, or reload", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await waitForOfflineReady(page);
+    // Nudge the view once so tile requests happen while the worker
+    // controls the page (initial-load tiles may predate control).
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await page.waitForTimeout(1500);
+    await expect
+      .poll(() => cachedTileCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    // Go offline (dropping the tile mock so fetches genuinely fail) and
+    // open a far, never-viewed area via document navigation.
+    await context.setOffline(true);
+    await context.unroute("https://*.basemaps.cartocdn.com/**");
+    await page.goto("/map?map=35.85,51.65,12", {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    // Failed tiles stay in the DOM without the loaded marker.
+    const errorTileSrcs = (): Promise<string[]> =>
+      page.evaluate(() =>
+        [...document.querySelectorAll("img.leaflet-tile")]
+          .filter(
+            (img) =>
+              !(img as HTMLImageElement).classList.contains(
+                "leaflet-tile-loaded",
+              ),
+          )
+          .map((img) => (img as HTMLImageElement).src),
+      );
+    await expect
+      .poll(async () => (await errorTileSrcs()).length, { timeout: 20_000 })
+      .toBeGreaterThan(0);
+    const failedUrls = await errorTileSrcs();
+    expect(failedUrls.length).toBeGreaterThan(0);
+
+    // Record view state, then reconnect WITHOUT any further gesture.
+    // Re-register the tile mock to stand in for the restored network so
+    // the test stays hermetic (no live tile servers).
+    await page.evaluate(() => {
+      (window as unknown as { __reconnectMarker?: number }).__reconnectMarker = 1;
+    });
+    const hrefBefore = page.url();
+    await context.setOffline(false);
+    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        headers: { "Access-Control-Allow-Origin": "*" },
+        body: PNG_1PX,
+      }),
+    );
+
+    // The exact previously-failed tiles must load on their own: same view,
+    // no pan/zoom/reset — recovery targets what is visible.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (srcs: string[]) => {
+            const loaded = new Set(
+              [...document.querySelectorAll("img.leaflet-tile-loaded")].map(
+                (img) => (img as HTMLImageElement).src,
+              ),
+            );
+            return srcs.filter((s) => loaded.has(s)).length;
+          }, failedUrls),
+        { timeout: 20_000 },
+      )
+      .toBe(failedUrls.length);
+
+    // No reload, no navigation, no view reset for the recovery itself.
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __reconnectMarker?: number }).__reconnectMarker,
+      ),
+    ).toBe(1);
+    expect(page.url()).toBe(hrefBefore);
+    // Offline banner is gone once back online.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("offline banner tracks connectivity even with cached tiles", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await waitForOfflineReady(page);
+    // Same nudge: ensure post-control tile requests exist to cache.
+    await page.getByRole("button", { name: "Zoom in" }).click();
+    await page.waitForTimeout(1500);
+    await expect
+      .poll(() => cachedTileCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    // Online: no banner.
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+
+    // Offline: banner appears even though visible tiles serve from cache.
+    await context.setOffline(true);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/قبلاً دیده‌اید/)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Model PWA resume: connectivity resync via dispatched events.
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("offline"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Back online: banner removes itself automatically, no success toast.
+    await context.setOffline(false);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("save notice shows once while online, never stacked offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/map", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // First online visit: informational notice, info styling, no cache words.
+    await expect(
+      page.getByText("ذخیره برای استفاده آفلاین", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Dismiss persists: reload online → notice gone.
+    await page.getByRole("button", { name: "بستن" }).first().click();
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByText("ذخیره برای استفاده آفلاین", { exact: true }),
+    ).toHaveCount(0);
+
+    // Offline visit shape: offline banner wins, no stacking.
+    await context.setOffline(true);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await context.setOffline(false);
+  });
+});

--- a/tests/map-tiles.spec.ts
+++ b/tests/map-tiles.spec.ts
@@ -119,23 +119,29 @@ test.describe("CARTO opportunistic tile cache", () => {
     await expect
       .poll(async () => (await tileUrls(page)).length, { timeout: 30_000 })
       .toBeGreaterThan(0);
-    const urls = await tileUrls(page);
-    // Only genuinely viewed tiles, all matching the narrow rule.
-    expect(urls.length).toBeLessThanOrEqual(300);
-    expect(urls.every((u) => TILE_KEY_RE.test(u))).toBe(true);
-    // Every cached entry is a real CORS response — never opaque.
-    const entryTypes = await page.evaluate(async () => {
+    // Single atomic snapshot: keys + entries together, so tiles cached
+    // between two reads cannot skew the assertions.
+    const entries = await page.evaluate(async () => {
       const cache = await caches.open("metto-carto-tiles");
-      const out: { status: number; type: string }[] = [];
+      const out: { url: string; status: number; type: string }[] = [];
       for (const req of await cache.keys()) {
         const res = await cache.match(req);
-        if (res) out.push({ status: res.status, type: res.type });
+        out.push({
+          url: req.url,
+          status: res ? res.status : -1,
+          type: res ? res.type : "missing",
+        });
       }
       return out;
     });
-    expect(entryTypes.length).toBe(urls.length);
-    expect(entryTypes.every((e) => e.status === 200 && e.type === "cors")).toBe(true);
-    expect(entryTypes.some((e) => e.type === "opaque")).toBe(false);
+    const urls = entries.map((e) => e.url);
+    // Only genuinely viewed tiles, all matching the narrow rule.
+    expect(urls.length).toBeGreaterThan(0);
+    expect(urls.length).toBeLessThanOrEqual(300);
+    expect(urls.every((u) => TILE_KEY_RE.test(u))).toBe(true);
+    // Every cached entry is a real CORS response — never opaque.
+    expect(entries.every((e) => e.status === 200 && e.type === "cors")).toBe(true);
+    expect(entries.some((e) => e.type === "opaque")).toBe(false);
     expect(await foreignCachedUrls(page)).toEqual([]);
 
     const after = await storageUsage(page);
@@ -160,7 +166,7 @@ test.describe("CARTO opportunistic tile cache", () => {
       offlinePage.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      offlinePage.getByText(/نقشه پایه به اینترنت نیاز دارد/),
+      offlinePage.getByText("بدون اینترنت", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
     // Cached tile returns 200 offline (served by the worker cache).

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Offline bottom-navigation: tapping static tabs while offline must open
+// them via full-document navigation (served from precache), because
+// client-side RSC fetches cannot succeed offline. Uses the mobile
+// viewport so the bottom tab bar (the reported component) is exercised.
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+async function waitForOfflineReady(page: Page) {
+  const status = page.getByTestId("offline-status");
+  await expect(status).toBeAttached({ timeout: 60_000 });
+  await expect
+    .poll(
+      async () =>
+        status.getAttribute("data-phase").then((p) => p ?? "unknown"),
+      { timeout: 60_000 },
+    )
+    .not.toBe("preparing");
+  const phase = await status.getAttribute("data-phase");
+  expect(["ready", "offline-ready"]).toContain(phase);
+}
+
+/** Route result is visible (arrival stat + line badge). */
+async function expectRouteResult(page: Page) {
+  await expect(page.getByText("رسیدن", { exact: true }).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("خط", { exact: false }).first()).toBeVisible();
+}
+
+async function pathname(page: Page): Promise<string> {
+  return new URL(page.url()).pathname;
+}
+
+/** The mobile bottom tab bar (the reported component). */
+function bottomNav(page: Page) {
+  return page.locator("div.fixed.bottom-0 nav");
+}
+
+function tabLink(page: Page, name: string) {
+  return bottomNav(page).getByRole("link", { name, exact: true });
+}
+
+test.describe("Offline bottom navigation", () => {
+  test("Route → Map → Stations → Nearby → Route all open offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/?from=ahang&to=aliabad", {
+      waitUntil: "domcontentloaded",
+    });
+    await waitForOfflineReady(page);
+    await expectRouteResult(page);
+
+    // The Route tab preserves the query in both modes.
+    const routeHref = await tabLink(page, "مسیر").getAttribute("href");
+    expect(routeHref).toContain("from=ahang");
+    expect(routeHref).toContain("to=aliabad");
+
+    await context.setOffline(true);
+
+    // Mechanism guard: offline taps must not issue client-side *navigation*
+    // RSC requests at all (they are what used to abort the transition).
+    // Link prefetch requests also carry `RSC: 1` (plus
+    // `Next-Router-Prefetch`) — those stay allowed and are excluded here.
+    const navRscRequests: string[] = [];
+    page.on("request", (req) => {
+      void Promise.all([
+        req.headerValue("rsc"),
+        req.headerValue("next-router-prefetch"),
+      ]).then(([rsc, prefetch]) => {
+        if (rsc !== null && prefetch === null) navRscRequests.push(req.url());
+      });
+    });
+
+    await tabLink(page, "نقشه").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/map");
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await tabLink(page, "ایستگاه‌ها").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/stations",
+    );
+    await expect(
+      page.getByPlaceholder("جستجوی ایستگاه…"),
+    ).toBeVisible({ timeout: 30_000 });
+
+    await tabLink(page, "نزدیک من").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe(
+      "/nearby",
+    );
+    await expect(
+      page.getByText("موقعیت شما", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Back to Route: same href semantics as online, route state intact.
+    await tabLink(page, "مسیر").click();
+    await expect.poll(() => pathname(page), { timeout: 30_000 }).toBe("/");
+    expect(new URL(page.url()).searchParams.get("from")).toBe("ahang");
+    expect(new URL(page.url()).searchParams.get("to")).toBe("aliabad");
+    await expectRouteResult(page);
+    // Flush any in-flight header reads, then assert zero navigation RSC.
+    await page.waitForTimeout(1000);
+    expect(navRscRequests).toEqual([]);
+
+    await context.setOffline(false);
+  });
+
+  test("modifier clicks keep normal browser semantics offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await waitForOfflineReady(page);
+    await context.setOffline(true);
+
+    // Ctrl-click must NOT trigger the offline document navigation on this
+    // page: the current tab stays put (the browser handles the new tab).
+    await tabLink(page, "نقشه").click({ modifiers: ["Control"] });
+    await page.waitForTimeout(2000);
+    expect(await pathname(page)).toBe("/");
+    // Clean up any tab the browser opened for the modifier click.
+    for (const p of context.pages()) {
+      if (p !== page) await p.close();
+    }
+
+    await context.setOffline(false);
+  });
+});

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -220,6 +220,59 @@ test.describe("Metto offline PWA", () => {
     );
   });
 
+  test("map overlay cards never overlap, online or offline", async ({
+    context,
+  }) => {
+    const page = await context.newPage();
+    const pinsUrl =
+      `/map?from=${ORIGIN_ID}&to=${DEST_ID}` +
+      `&op=35.7448,51.3755,مبدأ تست` +
+      `&dp=35.7000,51.4000,مقصد تست`;
+    await page.goto(pinsUrl, { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('[aria-label="Tehran metro on real map"]'),
+    ).toBeVisible({ timeout: 30_000 });
+
+    async function assertStackedTopToBottom() {
+      // Every visible card in the top stack must sit fully below the
+      // previous one (2px tolerance for subpixel rounding).
+      const boxes: Array<{ y: number; height: number }> = [];
+      for (const testid of ["map-offline-banner", "map-place-card"]) {
+        const loc = page.getByTestId(testid);
+        const count = await loc.count();
+        for (let i = 0; i < count; i++) {
+          const box = await loc.nth(i).boundingBox();
+          // Only consider actually rendered cards.
+          if (box && box.height > 0) boxes.push(box);
+        }
+      }
+      // Order top-to-bottom as they appear in the stack.
+      boxes.sort((a, b) => a.y - b.y);
+      expect(boxes.length).toBeGreaterThanOrEqual(2);
+      for (let i = 1; i < boxes.length; i++) {
+        expect(boxes[i].y).toBeGreaterThanOrEqual(
+          boxes[i - 1].y + boxes[i - 1].height - 2,
+        );
+      }
+    }
+
+    // Online: save notice + 2 place cards stacked without overlap.
+    await expect(page.getByTestId("map-place-card")).toHaveCount(2, {
+      timeout: 15_000,
+    });
+    await assertStackedTopToBottom();
+
+    // Offline: banner replaces the notice; banner + 2 cards still stacked.
+    await context.setOffline(true);
+    await expect(
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("map-offline-banner")).toBeVisible();
+    await expect(page.getByTestId("map-place-card")).toHaveCount(2);
+    await assertStackedTopToBottom();
+    await context.setOffline(false);
+  });
+
   test("waiting worker stays silent, never reloads, activates naturally", async ({
     context,
   }) => {

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -177,7 +177,7 @@ test.describe("Metto offline PWA", () => {
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await expect(
-      page.getByText(/نقشه پایه به اینترنت نیاز دارد/),
+      page.getByText("بدون اینترنت", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
     // 18-20. Landmark search explains the Internet requirement offline.
@@ -284,6 +284,7 @@ test.describe("Metto offline PWA", () => {
 
       // Old clients disappear → the waiting worker activates naturally, and
       // the next launch is controlled by it. No SKIP_WAITING, no reload loop.
+      // Generous timeout: activation competes with parallel suite load.
       await page.close();
       const page2 = await context.newPage();
       await page2.goto("/", { waitUntil: "domcontentloaded" });
@@ -297,7 +298,7 @@ test.describe("Metto offline PWA", () => {
                 waiting: !!reg?.waiting,
               };
             }),
-          { timeout: 30_000 },
+          { timeout: 60_000 },
         )
         .toEqual({ controlled: true, waiting: false });
       await waitForOfflineReady(page2);


### PR DESCRIPTION
Follow-up to the map/offline UX work: fixes overlaid map cards (offline banner colliding with place cards, fa).

**Cause:** overlays were separately absolutely-positioned siblings with hardcoded top offsets (`top-14` banner vs `top-28` place list) that assumed fixed card heights. The 3-line Persian offline banner (~110px) overflows the 112px offset, so cards render underneath it.

**Fix (`app/map/client.tsx` only):** one absolute flex-col stack container; banner, save notice, and place cards lay out in normal flow. No copy/design/z-index changes; toggle and bottom sheet untouched.

**Tests:** new `map overlay cards never overlap` E2E in `tests/offline.spec.ts` asserts bounding-box stacking (2px tolerance) online (notice+2 cards) and offline (banner+2 cards). Negative control verified: fails on old layout, passes on new. Full suite: tsc clean, vitest 138 passed, build OK (46 precached URLs), Playwright 10/10.