### PR TITLE
Deterministic offline reconnect recovery plus durable readiness gate

### DIFF
--- a/components/real-map.tsx
+++ b/components/real-map.tsx
@@ -153,12 +153,17 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
   const [gpsError, setGpsError] = useState<string | null>(null)
   const isFa = lang === "fa"
   const { state: connectivity } = useConnectivity()
-  // Tracks the previous EFFECTIVE connectivity state so only a real
-  // offline → online transition triggers a retry. In particular,
-  // checking → online (e.g. after a pageshow resync while already online)
-  // must not redraw: nothing failed, so there is nothing to retry.
-  // An initial online mount is likewise not a transition.
-  const prevConnectivityRef = useRef<ConnectivityState>(connectivity)
+  // Tracks the previous SETTLED connectivity state so only a real
+  // offline → online transition triggers a retry. The machine always
+  // interposes "checking" between offline and online on the event-driven
+  // path, so comparing consecutive renders would consume the edge on the
+  // checking render and never redraw. In particular, a settled
+  // online → … → online resync (e.g. pageshow while already online) must
+  // not redraw: nothing failed, so there is nothing to retry. An initial
+  // online mount is likewise not a transition.
+  const lastSettledConnectivityRef = useRef<ConnectivityState | null>(
+    connectivity === "checking" ? null : connectivity,
+  )
 
   const edges = useMemo(() => buildMapEdges(), [])
   const routeStations = useMemo(() => new Set(route?.path ?? []), [route])
@@ -477,13 +482,16 @@ export function RealMap({ lang, mapMode, route, originId, destId, selectedId, on
 
   // Retry the active basemap layer(s) when EFFECTIVE connectivity returns,
   // so tiles that failed while offline start loading without any zoom/pan
-  // gesture. Runs only on a real offline → online transition of the shared
-  // state (checking → online is not one). No remount, no view reset, no
-  // overlay or cache touch.
+  // gesture. Runs only on a settled offline → online transition of the
+  // shared state ("checking" renders are skipped, so the machine's
+  // offline → checking → online recovery still redraws exactly once,
+  // while online → checking → online resyncs never do). No remount, no
+  // view reset, no overlay or cache touch.
   useEffect(() => {
-    const was = prevConnectivityRef.current
-    prevConnectivityRef.current = connectivity
-    if (was !== "offline" || connectivity !== "online") return
+    if (connectivity === "checking") return
+    const wasSettled = lastSettledConnectivityRef.current
+    lastSettledConnectivityRef.current = connectivity
+    if (wasSettled !== "offline" || connectivity !== "online") return
     const map = mapRef.current
     if (!map) return
     for (const layer of [tileLayerRef.current, minimalistLayerRef.current, labelsLayerRef.current]) {

--- a/lib/offline/use-offline-readiness.ts
+++ b/lib/offline/use-offline-readiness.ts
@@ -4,7 +4,9 @@
 // 1. "preparing": online-but-incomplete, OR offline with verification still
 //    pending (UNKNOWN — must never warn).
 // 2. "ready": online + SW controlling + schedule + holiday dataset present.
-// 3. "offline-ready": offline + verified + core data available.
+// 3. "offline-ready": offline + verified + core data available from the
+//    durable SW precache guarantee (Cache Storage — never incidental
+//    HTTP-cache availability).
 // 4. "offline-incomplete": offline + VERIFIED missing core (the only warning).
 //
 // "Core ready" NEVER claims readiness from SW install alone — the timetable
@@ -285,7 +287,10 @@ export function useOfflineReadiness(): OfflineReadiness {
   // because verification took longer than the UI grace period.
   // Tri-state aware: "checking" connectivity is neither online nor offline —
   // it follows the online path (preparing/ready) so nothing offline is ever
-  // claimed before reachability resolves.
+  // claimed before reachability resolves. Offline "ready" additionally
+  // requires precacheReady: scheduleLoaded may be true from the incidental
+  // browser HTTP cache while the durable Cache Storage guarantee is gone —
+  // that must report offline-incomplete, never offline-ready.
   const readinessVerified =
     scheduleChecked && holidayChecked && precacheChecked;
   const confirmedOffline = connectivity.state === "offline";
@@ -297,7 +302,7 @@ export function useOfflineReadiness(): OfflineReadiness {
   } else if (!readinessVerified) {
     phase = "preparing";
   } else {
-    phase = coreReady ? "offline-ready" : "offline-incomplete";
+    phase = coreReady && precacheReady ? "offline-ready" : "offline-incomplete";
   }
 
   return {

--- a/tests/map-reconnect.spec.ts
+++ b/tests/map-reconnect.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test, type BrowserContext, type Page } from "@playwright/test";
 
-// Map recovery + deterministic offline banner. Mocked CARTO tiles only,
-// no live servers.
+// Map recovery + deterministic offline banner. CARTO tiles never touch the
+// network here: a test-side image shim rewrites every CARTO <img> assignment
+// (healthy data-URL PNG vs guaranteed-404 local URL), so no live servers.
 const PNG_1PX = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
   "base64",
@@ -47,81 +48,255 @@ test.describe("Map reconnect recovery", () => {
   test("missing tiles reload on reconnect without pan, zoom, or reload", async ({
     context,
   }) => {
+    // Deterministic test-side fault injection (no product hooks, no network
+    // dependence, no gestures). Every CARTO Leaflet tile <img> assignment is
+    // rewritten BEFORE any fetch, so tile outcomes never depend on the
+    // network or on service-worker fetch behavior (worker-initiated requests
+    // bypass both Playwright offline emulation and route interception):
+    // - mode "mock": serve a valid 1px data-URL PNG (healthy tiles, zero
+    //   network, nothing cached — cache overlap cannot affect this test).
+    // - mode "fail": point at a guaranteed-404 local URL, producing settled
+    //   `error` events through the genuine Leaflet tileerror path.
+    // The shim starts in "fail" mode so the initial tile set fails with no
+    // view change at all; the test flips to "mock" only for the recovery.
+    // Each rewrite records the ORIGINAL cartocdn URL, proving a real CARTO
+    // tile source was attempted both before and after reconnect. Only
+    // SETTLED `error`/`load` events count — never pending DOM class state.
+    await context.addInitScript(() => {
+      const w = window as unknown as {
+        __cartoFault?: {
+          mode: "mock" | "fail";
+          attempted: string[];
+          failed: string[];
+          loaded: number;
+        };
+      };
+      w.__cartoFault = { mode: "fail", attempted: [], failed: [], loaded: 0 };
+      const CARTO_RE = /basemaps\.cartocdn\.com/;
+      const FAIL_URL = "/__e2e_tile_fail__.png";
+      const OK_URL =
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const proto = HTMLImageElement.prototype;
+      const desc = Object.getOwnPropertyDescriptor(proto, "src");
+      if (desc && desc.set && desc.get) {
+        const origSet = desc.set;
+        const origGet = desc.get;
+        Object.defineProperty(proto, "src", {
+          configurable: true,
+          enumerable: desc.enumerable,
+          get(this: HTMLImageElement) {
+            return origGet.call(this);
+          },
+          set(this: HTMLImageElement, v: unknown) {
+            const url = String(v);
+            if (CARTO_RE.test(url)) {
+              const st = (
+                window as unknown as {
+                  __cartoFault?: {
+                    mode: "mock" | "fail";
+                    attempted: string[];
+                    failed: string[];
+                    loaded: number;
+                  };
+                }
+              ).__cartoFault;
+              st?.attempted.push(url);
+              try {
+                this.dataset.cartoShim = "1";
+                this.dataset.cartoOriginal = url;
+              } catch {
+                // dataset best-effort only; events still counted.
+              }
+              origSet.call(this, st?.mode === "fail" ? FAIL_URL : OK_URL);
+              return;
+            }
+            origSet.call(this, v as string);
+          },
+        });
+      }
+      const shimmed = (e: Event): HTMLImageElement | null => {
+        const t = e.target as HTMLImageElement | null;
+        return t && t.tagName === "IMG" && t.dataset?.cartoShim === "1"
+          ? t
+          : null;
+      };
+      document.addEventListener(
+        "error",
+        (e) => {
+          const t = shimmed(e);
+          if (!t) return;
+          const st = (
+            window as unknown as {
+              __cartoFault?: { failed: string[] };
+            }
+          ).__cartoFault;
+          st?.failed.push(t.dataset.cartoOriginal ?? t.src);
+        },
+        true,
+      );
+      document.addEventListener(
+        "load",
+        (e) => {
+          if (!shimmed(e)) return;
+          const st = (
+            window as unknown as {
+              __cartoFault?: { loaded: number };
+            }
+          ).__cartoFault;
+          if (st) st.loaded += 1;
+        },
+        true,
+      );
+    });
+
+    // Hermeticity guard: with every CARTO assignment rewritten above, no
+    // cartocdn request may ever issue; abort any that does so a leak fails
+    // loudly instead of reaching live servers.
+    await context.unroute("https://*.basemaps.cartocdn.com/**");
+    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
+      route.abort("blockedbyclient"),
+    );
+    const cartoRequests: string[] = [];
     const page = await context.newPage();
+    page.on("request", (req) => {
+      if (req.url().includes("basemaps.cartocdn.com")) {
+        cartoRequests.push(req.url());
+      }
+    });
+
+    type FaultStats = { attempted: string[]; failed: string[]; loaded: number };
+    const faultStats = (): Promise<FaultStats> =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __cartoFault?: FaultStats & { mode: string };
+            }
+          ).__cartoFault ?? { attempted: [], failed: [], loaded: 0 },
+      );
+    const setFaultMode = (mode: "mock" | "fail"): Promise<void> =>
+      page.evaluate((m) => {
+        (
+          window as unknown as {
+            __cartoFault?: { mode: string };
+          }
+        ).__cartoFault!.mode = m;
+      }, mode);
+    const effectiveConnectivity = (): Promise<string | null> =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __mettoOffline?: { connectivity?: string };
+            }
+          ).__mettoOffline?.connectivity ?? null,
+      );
+
     await page.goto("/map", { waitUntil: "domcontentloaded" });
     await expect(
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await waitForOfflineReady(page);
-    // Nudge the view once so tile requests happen while the worker
-    // controls the page (initial-load tiles may predate control).
-    await page.getByRole("button", { name: "Zoom in" }).click();
-    await page.waitForTimeout(1500);
-    await expect
-      .poll(() => cachedTileCount(page), { timeout: 30_000 })
-      .toBeGreaterThan(0);
 
-    // Go offline (dropping the tile mock so fetches genuinely fail) and
-    // open a far, never-viewed area via document navigation.
-    await context.setOffline(true);
-    await context.unroute("https://*.basemaps.cartocdn.com/**");
-    await page.goto("/map?map=35.85,51.65,12", {
-      waitUntil: "domcontentloaded",
-    });
+    // Fail-first (no gestures at all): the shim starts in "fail" mode, so
+    // the initial tile set genuinely fails through the Leaflet tileerror
+    // path while the map itself loads normally (vectors render; planner and
+    // readiness never depend on tiles). SETTLED-gate: only `error` events
+    // prove failure — in-flight tiles are excluded by requiring every
+    // assigned image to have settled.
+    await expect
+      .poll(
+        async () => {
+          const s = await faultStats();
+          if (s.attempted.length === 0) return 0;
+          if (s.failed.length + s.loaded < s.attempted.length) return 0;
+          return s.failed.length;
+        },
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThan(0);
+    const initial = await faultStats();
+    expect(initial.attempted.length).toBeGreaterThan(0);
+    expect(initial.attempted[0]).toMatch(/basemaps\.cartocdn\.com/);
+    expect(initial.failed.length).toBeGreaterThan(0);
+
+    // Effective offline WITHOUT browser offline (worker-initiated fetches
+    // ignore offline emulation, and tile outcomes here don't need it):
+    // backstop the reachability probe, then dispatch the browser offline
+    // event the shared connectivity machine listens for. No pan/zoom/nav.
+    await context.route("**/api/connectivity", (route) =>
+      route.abort("failed"),
+    );
+    await page.evaluate(() => window.dispatchEvent(new Event("offline")));
+    await expect
+      .poll(() => effectiveConnectivity(), { timeout: 15_000 })
+      .toBe("offline");
     await expect(
-      page.locator('[aria-label="Tehran metro on real map"]'),
-    ).toBeVisible({ timeout: 30_000 });
-    // Failed tiles stay in the DOM without the loaded marker.
-    const errorTileSrcs = (): Promise<string[]> =>
-      page.evaluate(() =>
-        [...document.querySelectorAll("img.leaflet-tile")]
-          .filter(
-            (img) =>
-              !(img as HTMLImageElement).classList.contains(
-                "leaflet-tile-loaded",
-              ),
-          )
-          .map((img) => (img as HTMLImageElement).src),
-      );
-    await expect
-      .poll(async () => (await errorTileSrcs()).length, { timeout: 20_000 })
-      .toBeGreaterThan(0);
-    const failedUrls = await errorTileSrcs();
-    expect(failedUrls.length).toBeGreaterThan(0);
+      page.getByText("بدون اینترنت", { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
 
-    // Record view state, then reconnect WITHOUT any further gesture.
-    // Re-register the tile mock to stand in for the restored network so
-    // the test stays hermetic (no live tile servers).
+    // Fail phase needs no gesture: the initial failures above already
+    // settled, and the offline window stays short (seconds), far below the
+    // ~25 s background retry cadence, so no spurious transition can
+    // interleave.
+    const before = await faultStats();
+    expect(before.failed.length).toBeGreaterThan(0);
+    const failedBefore = [...before.failed];
+
+    // Record view state, then reconnect WITHOUT any further gesture: allow
+    // retries, restore reachability, and dispatch the browser online event
+    // so the product's existing offline→online layer.redraw() fires.
     await page.evaluate(() => {
       (window as unknown as { __reconnectMarker?: number }).__reconnectMarker = 1;
     });
     const hrefBefore = page.url();
-    await context.setOffline(false);
-    await context.route("https://*.basemaps.cartocdn.com/**", (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "image/png",
-        headers: { "Access-Control-Allow-Origin": "*" },
-        body: PNG_1PX,
-      }),
-    );
+    await setFaultMode("mock");
+    await context.unroute("**/api/connectivity");
+    await page.evaluate(() => window.dispatchEvent(new Event("online")));
 
-    // The exact previously-failed tiles must load on their own: same view,
-    // no pan/zoom/reset — recovery targets what is visible.
+    // Effective connectivity recovers through the real probe path.
+    await expect
+      .poll(() => effectiveConnectivity(), { timeout: 15_000 })
+      .toBe("online");
+
+    // The retry proof: NEW CARTO assignments appear with no pan/zoom/nav —
+    // only the product's redraw can have issued them — and they settle
+    // successfully, including the exact previously-failed tile sources.
+    await expect
+      .poll(async () => (await faultStats()).attempted.length, {
+        timeout: 20_000,
+      })
+      .toBeGreaterThan(before.attempted.length);
+    await expect
+      .poll(async () => (await faultStats()).loaded, { timeout: 20_000 })
+      .toBeGreaterThan(before.loaded);
+    const after = await faultStats();
+    expect(
+      after.attempted.filter((u) => failedBefore.includes(u)).length,
+    ).toBeGreaterThan(0);
+
+    // Failed state clears from the DOM: every visible tile settled loaded.
     await expect
       .poll(
         async () =>
-          page.evaluate(async (srcs: string[]) => {
-            const loaded = new Set(
-              [...document.querySelectorAll("img.leaflet-tile-loaded")].map(
-                (img) => (img as HTMLImageElement).src,
-              ),
-            );
-            return srcs.filter((s) => loaded.has(s)).length;
-          }, failedUrls),
+          page.evaluate(
+            () =>
+              [...document.querySelectorAll("img.leaflet-tile")].filter(
+                (img) =>
+                  !(img as HTMLImageElement).classList.contains(
+                    "leaflet-tile-loaded",
+                  ),
+              ).length,
+          ),
         { timeout: 20_000 },
       )
-      .toBe(failedUrls.length);
+      .toBe(0);
+    await expect(
+      page.evaluate(
+        () =>
+          document.querySelectorAll("img.leaflet-tile-loaded").length,
+      ),
+    ).resolves.toBeGreaterThan(0);
 
     // No reload, no navigation, no view reset for the recovery itself.
     expect(
@@ -134,6 +309,8 @@ test.describe("Map reconnect recovery", () => {
     await expect(
       page.getByText("بدون اینترنت", { exact: true }),
     ).toHaveCount(0);
+    // No live tile dependency at any point in this test.
+    expect(cartoRequests).toEqual([]);
   });
 
   test("offline banner tracks connectivity even with cached tiles", async ({

--- a/tests/map-reconnect.spec.ts
+++ b/tests/map-reconnect.spec.ts
@@ -261,7 +261,9 @@ test.describe("Map reconnect recovery", () => {
 
     // The retry proof: NEW CARTO assignments appear with no pan/zoom/nav —
     // only the product's redraw can have issued them — and they settle
-    // successfully, including the exact previously-failed tile sources.
+    // successfully. The overlap check slices off the pre-reconnect attempts
+    // so it inspects only post-reconnect retries: at least one retried
+    // assignment must match an exact previously-failed tile source.
     await expect
       .poll(async () => (await faultStats()).attempted.length, {
         timeout: 20_000,
@@ -271,8 +273,9 @@ test.describe("Map reconnect recovery", () => {
       .poll(async () => (await faultStats()).loaded, { timeout: 20_000 })
       .toBeGreaterThan(before.loaded);
     const after = await faultStats();
+    const retried = after.attempted.slice(before.attempted.length);
     expect(
-      after.attempted.filter((u) => failedBefore.includes(u)).length,
+      retried.filter((u) => failedBefore.includes(u)).length,
     ).toBeGreaterThan(0);
 
     // Failed state clears from the DOM: every visible tile settled loaded.


### PR DESCRIPTION
Fixes two e2e failures (full suite now 18/18 green) with zero timer/connectivity/SW changes.

1. tests/map-reconnect.spec.ts: hermetic fault-injection redesign - test-side CARTO img shim (fail-first 404 vs data-URL mock), settled error/load events only, effective offline/online via connectivity events, no gestures, no live servers. Previously the precondition counted pending tiles and SW tile fetches bypassed Playwright offline controls.

2. components/real-map.tsx: redraw basemap tiles on settled offline-to-online transitions. The machine always interposes checking on the event-driven path, so the old consecutive-render check never redrew on genuine recovery. Verified: no redraw on mount, none on online resync, exactly once on recovery; background-retry path preserved (connectivity E green).

3. lib/offline/use-offline-readiness.ts: offline-ready requires coreReady and precacheReady, so evicted core data can no longer report ready via incidental HTTP cache.

Validation: reconnect 10/10, reconnect suite 15/15, missing-core 5/5, stacking 1/1, full Playwright 18/18, tsc clean, vitest 161/161, pnpm build green.