### PR TITLE
chore(vercel): remove duplicate build command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "buildCommand": "next build && serwist build",
   "crons": [
     {
       "path": "/api/cron/sync-holidays",


### PR DESCRIPTION
Removes the top-level buildCommand from vercel.json so the package.json build script is the single source of truth for local, CI, and Vercel builds.

Audit: Vercel uses package.json scripts.build for the Next.js preset when no override is set, and vercel.json buildCommand duplicated that chain. The dashboard Build Command override (stale v0 inject script) should additionally be switched OFF in Project Settings so the repo script takes effect.

Scope: vercel.json only, one line deleted. No package.json, Serwist, service-worker, PWA, or WebMCP changes.

Validation:
- vercel.json parses as JSON, no buildCommand key, crons and headers intact
- pnpm build succeeds: next build (13/13 pages) && scripts/generate-version.mjs (public/version.json matches .next/BUILD_ID) && serwist build (public/sw.js, 47 URLs precached)