### PR TITLE
chore(privacy): remove Fingerprint identification

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -59,7 +59,7 @@ respective licenses and terms, including but not limited to:
   policy applies).
 * npm dependencies per their own licenses (mostly MIT/Apache-2.0/BSD;
   `@vercel/analytics` is MPL-2.0). Proprietary services used at
-  runtime (e.g. Fingerprint, Upstash, timestamp.ir, CARTO, Esri) are
+  runtime (e.g. Upstash, timestamp.ir, CARTO, Esri) are
   governed by their own terms.
 
 ## Deployments of modified versions

--- a/app/home-page.tsx
+++ b/app/home-page.tsx
@@ -13,7 +13,6 @@ import {
   Map as MapIcon,
   X,
 } from "lucide-react";
-import { useVisitorData } from "@fingerprint/react";
 import { StationCombobox } from "@/components/station-combobox";
 import { RoutePanel } from "@/components/route-panel";
 import { RouteActions } from "@/components/route-actions";
@@ -82,7 +81,6 @@ function readStoredPlaceInfo(storageKey: string, stationId: string | null): Plac
 export function HomePage() {
   const loaded = useScheduleData();
   const { isHolidayDate } = useHolidayData();
-  const { getData } = useVisitorData({ immediate: true });
   const {
     lang,
     setOriginId: setCtxOrigin,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata, Viewport } from "next";
 import { Vazirmatn } from "next/font/google";
-import { FingerprintProvider } from "@fingerprint/react";
 import { MetroProvider } from "./providers";
 import { SerwistProvider } from "./serwist";
 import { AppNav } from "./nav";
@@ -192,15 +191,10 @@ export default function RootLayout({
           cacheOnNavigation={false}
           disable={process.env.NODE_ENV === "development"}
         >
-        <FingerprintProvider
-          apiKey="PeMqnfaeFyuBBJjOvNQ5"
-          region="us"
-        >
-          <MetroProvider>
-            <AppNav />
-            <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden pb-[60px] pb-[calc(60px+env(safe-area-inset-bottom))] md:pb-0">{children}</div>
-          </MetroProvider>
-        </FingerprintProvider>
+        <MetroProvider>
+          <AppNav />
+          <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden pb-[60px] pb-[calc(60px+env(safe-area-inset-bottom))] md:pb-0">{children}</div>
+        </MetroProvider>
         </SerwistProvider>
         {process.env.NODE_ENV === "production" && <Analytics />}
         {process.env.NODE_ENV === "production" && <SpeedInsights />}

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -14,7 +14,7 @@
 // - NetworkFirst: /holidays.version.json update pointer (not precached)
 // - NetworkOnly: same-origin /api/* and version-pinned dataset downloads
 // - Cross-origin: NO blanket route — unmatched requests (Nominatim,
-//   Esri, timestamp.ir, fonts, fingerprint, …) are handled directly by the
+//   Esri, timestamp.ir, fonts, …) are handled directly by the
 //   browser, never cached. Sole exception: the narrow opportunistic CARTO
 //   raster-tile rule below (policy-bounded, see lib/map/carto-tiles.ts).
 // Only cacheable responses are ever stored (no errors, no redirects).

--- a/lib/map/carto-tiles.ts
+++ b/lib/map/carto-tiles.ts
@@ -12,7 +12,7 @@
 // - nothing older than MAX_CARTO_TILE_AGE_S (30 days);
 // - ONLY tiles the user naturally viewed (Leaflet <img> requests) —
 //   no prefetch, no enumeration, no zoom-level crawling, no offline packs.
-// - Esri, Nominatim, timestamp.ir, FingerprintJS and every other
+// - Esri, Nominatim, timestamp.ir and every other
 //   third-party host structurally cannot match.
 //
 // This cache is OPTIONAL: it is not part of offline readiness, and an

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "generate:stations": "node scripts/generate-stations.ts"
   },
   "dependencies": {
-    "@fingerprint/react": "^3.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/leaflet": "^1.9.21",
     "@upstash/redis": "^1.38.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,6 @@ importers:
 
   .:
     dependencies:
-      '@fingerprint/react':
-        specifier: ^3.1.0
-        version: 3.1.0(react@19.2.7)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(supports-color@7.2.0)(zod@4.4.3)
@@ -575,14 +572,6 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@fingerprint/agent@4.1.3':
-    resolution: {integrity: sha512-kD7x3cYpOETFZ6KKOzozwGsCYhApRa/n8sDA+oLjx0jRVarmxisMMUi5UtGJQHdx8jqxU+I/8gcjb+fuSBxhBA==}
-
-  '@fingerprint/react@3.1.0':
-    resolution: {integrity: sha512-oGOuNXVVqL/pickBnk+fzkcyHe79NSA5tX54vE8j0+TlxpgQNDgzXhU24am1Yi+qlOuf/MwCuMPfppFzPTXrTg==}
-    peerDependencies:
-      react: '>=18 <20'
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4588,13 +4577,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
-
-  '@fingerprint/agent@4.1.3': {}
-
-  '@fingerprint/react@3.1.0(react@19.2.7)':
-    dependencies:
-      '@fingerprint/agent': 4.1.3
-      react: 19.2.7
 
   '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 overrides:
   hono: 4.12.25
 allowBuilds:
-  '@fingerprint/react': true
   esbuild: true
   msw: true
   sharp: true


### PR DESCRIPTION
Closes #39

Drop \@fingerprint/react\ provider + \useVisitorData\ hook. The visitor ID was never consumed in app code (dashboard-curiosity only) while costing every load an \pcdn.io\ fetch and a \Protected Audience deprecated\ DevTools issue for all Chrome users.

**Changed (8 files, +7/−35):**
- \pp/layout.tsx\: remove \FingerprintProvider\ wrapper
- \pp/home-page.tsx\: remove \useVisitorData\ import + dead \getData\ hook
- \package.json\ / \pnpm-workspace.yaml\ / \pnpm-lock.yaml\: dep removed
- \NOTICE.md\, \pp/sw.ts\, \lib/map/carto-tiles.ts\: comment-only cleanup

**Verified:**
- \	sc --noEmit\ clean, \eslint\ 0 errors (3 pre-existing warnings in \home-page.tsx\), \itest\ 210/210 pass
- No other \@fingerprint\ references remain in app code (only third-party blocklist strings in tile-leak guards, intentionally kept)

**Note:** new dashboard Events stop after merge (history stays). Vercel Analytics + Speed Insights unchanged.