### PR TITLE
CI: Vercel bypass-cookie auth + SW tile header stripping

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,6 +103,19 @@ jobs:
             exit 1
           fi
           echo "Testing $BASE_URL"
+          echo "checked out: $(git rev-parse HEAD)"
+
+      - name: Probe Deployment Protection (status codes only)
+        # Diagnostic only, runs before the suite: proves whether the gate is
+        # open, in ~10 seconds instead of a 15-minute blind run. Prints STATUS
+        # CODES and public version metadata only — secrets are never printed.
+        # Read as: authed 200 = gate open, suite failures below are app/test
+        # issues; authed 302 = token rejected at the gate.
+        env:
+          VERCEL_TRUSTED_OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+        run: |
+          echo "deployment root with OIDC identity header -> HTTP $(curl -s -o /dev/null -w "%{http_code}" --max-time 30 -H "x-vercel-trusted-oidc-idp-token: $VERCEL_TRUSTED_OIDC_TOKEN" "$BASE_URL/")"
+          echo "deployment root anonymous -> HTTP $(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$BASE_URL/")"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -121,6 +134,10 @@ jobs:
           # mint; never printed, never persisted). Playwright sends it as
           # x-vercel-trusted-oidc-idp-token when present; locally unset.
           VERCEL_TRUSTED_OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+          # Long-lived automation bypass (GitHub Actions secret, never
+          # hardcoded, never printed). Playwright sends it as
+          # x-vercel-protection-bypass when present; locally unset.
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: pnpm test:e2e:preview
 
       - name: Upload failure artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ public/sw.js.map.txt
 # Playwright
 test-results/
 playwright-report/
+# Playwright bypass-cookie state (may hold a Vercel bypass grant)
+playwright/.auth/

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -34,6 +34,7 @@ import {
   MAX_CARTO_TILE_AGE_S,
   isCacheableTileResponse,
   isCartoTileRequest,
+  stripTileAuthHeaders,
 } from "../lib/map/carto-tiles";
 import {
   CANONICAL_STATIC_DOCS,
@@ -118,6 +119,17 @@ const serwist = new Serwist({
         event: ExtendableEvent;
       }) => {
         try {
+          // Privacy + CORS: first-party auth headers (set only by
+          // test/CI harnesses via page-context headers) must never leave
+          // our origin on tile requests. Besides leaking credentials to
+          // the tile CDN, custom headers force a CORS preflight on every
+          // tile fetch, which the CDN rejects — breaking tiles and their
+          // offline cache exactly where coverage matters. The cache key
+          // (URL) is untouched, and headerless traffic skips the rebuild.
+          const headers = new Headers(request.headers);
+          if (stripTileAuthHeaders(headers)) {
+            request = new Request(request, { headers });
+          }
           const response = await cartoTileStrategy.handle({ request, event });
           return response ?? Response.error();
         } catch {

--- a/lib/map/carto-tiles.test.ts
+++ b/lib/map/carto-tiles.test.ts
@@ -3,8 +3,10 @@ import {
   CARTO_TILE_CACHE,
   MAX_CARTO_TILES,
   MAX_CARTO_TILE_AGE_S,
+  TILE_STRIP_HEADERS,
   isCacheableTileResponse,
   isCartoTileRequest,
+  stripTileAuthHeaders,
 } from "./carto-tiles";
 
 const tile = (overrides: Partial<Parameters<typeof isCartoTileRequest>[0]> = {}) => ({
@@ -127,12 +129,37 @@ describe("tile response validation", () => {
     ).toBe(false);
   });
 });
-
 describe("tile cache bounds", () => {
   it("stays small and within the provider retention maximum", () => {
     expect(CARTO_TILE_CACHE).toBe("metto-carto-tiles");
     expect(MAX_CARTO_TILES).toBe(300);
     expect(MAX_CARTO_TILE_AGE_S).toBe(2_592_000);
     expect(MAX_CARTO_TILE_AGE_S).toBeLessThanOrEqual(30 * 24 * 60 * 60);
+  });
+});
+
+describe("tile auth header stripping", () => {
+  it("removes first-party auth headers and reports true", () => {
+    const headers = new Headers({
+      "x-vercel-trusted-oidc-idp-token": "token",
+      "x-vercel-protection-bypass": "secret",
+      "accept": "image/*",
+    });
+    expect(stripTileAuthHeaders(headers)).toBe(true);
+    expect(headers.has("x-vercel-trusted-oidc-idp-token")).toBe(false);
+    expect(headers.has("x-vercel-protection-bypass")).toBe(false);
+    expect(headers.get("accept")).toBe("image/*");
+  });
+
+  it("is a no-op returning false when no auth headers are present", () => {
+    const headers = new Headers({ accept: "image/*" });
+    expect(stripTileAuthHeaders(headers)).toBe(false);
+    expect(headers.get("accept")).toBe("image/*");
+  });
+
+  it("covers exactly the harness-injected header names", () => {
+    expect([...TILE_STRIP_HEADERS].sort()).toEqual(
+      ["x-vercel-protection-bypass", "x-vercel-trusted-oidc-idp-token"].sort(),
+    );
   });
 });

--- a/lib/map/carto-tiles.ts
+++ b/lib/map/carto-tiles.ts
@@ -66,6 +66,38 @@ export function isCartoTileRequest(req: CartoTileRequestShape): boolean {
   );
 }
 
+/**
+ * First-party auth headers that must never leave our origin on tile
+ * requests. Besides leaking credentials to the tile CDN, custom headers
+ * force a CORS preflight on every tile fetch, which the tile CDN rejects —
+ * breaking tiles (and their offline cache) in exactly the contexts that
+ * set such headers (e.g. authenticated test harnesses). Normal traffic
+ * never carries these headers, so stripping is a no-op for real users.
+ */
+export const TILE_STRIP_HEADERS: ReadonlyArray<string> = [
+  "x-vercel-trusted-oidc-idp-token",
+  "x-vercel-protection-bypass",
+];
+
+/**
+ * Remove first-party auth headers in place. Returns true when anything
+ * was removed (caller may then rebuild the request); never throws.
+ */
+export function stripTileAuthHeaders(headers: Headers): boolean {
+  let removed = false;
+  for (const name of TILE_STRIP_HEADERS) {
+    try {
+      if (headers.has(name)) {
+        headers.delete(name);
+        removed = true;
+      }
+    } catch {
+      // Immutable headers stay untouched; the fetch proceeds as-is.
+    }
+  }
+  return removed;
+}
+
 export interface TileResponseShape {
   status: number;
   /** Fetch response type: "basic" | "cors" | "opaque" | ... */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,11 @@ const chromiumPath = process.env.PLAYWRIGHT_CHROMIUM_PATH;
 // workflow), every context request carries it as a Trusted Sources identity
 // token. Absent locally: no header, unchanged behavior.
 const trustedOidcToken = process.env.VERCEL_TRUSTED_OIDC_TOKEN;
+// Automation bypass for the same gate: when set (CI secret, never
+// hardcoded), every context request additionally carries it as
+// x-vercel-protection-bypass. Absent locally: no header, unchanged
+// behavior — normal tests never depend on it.
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
 
 export default defineConfig({
   testDir: "./tests",
@@ -25,13 +30,34 @@ export default defineConfig({
   workers: 1,
   retries: 0,
   reporter: "list",
+  // Bypass-cookie bootstrap (see tests/global-setup.ts): stamps Vercel's
+  // protection-bypass cookie once per run when VERCEL_AUTOMATION_BYPASS_SECRET
+  // is set, so browser-initiated requests (notably SW script fetches, which
+  // carry no page-context headers) also pass Deployment Protection. Writes
+  // an empty state when unset — local runs behave identically either way.
+  globalSetup: "./tests/global-setup.ts",
   use: {
     baseURL: process.env.BASE_URL ?? "http://127.0.0.1:3000",
+    storageState: "playwright/.auth/state.json",
+    // Failure forensics: a screenshot shows WHAT html arrived (SSO login
+    // vs error page vs app), a trace shows WHY (console + network). Kept
+    // only for failures; green runs store nothing.
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
     ...(chromiumPath
       ? { launchOptions: { executablePath: chromiumPath } }
       : {}),
-    ...(trustedOidcToken
-      ? { extraHTTPHeaders: { "x-vercel-trusted-oidc-idp-token": trustedOidcToken } }
+    ...(trustedOidcToken || bypassSecret
+      ? {
+          extraHTTPHeaders: {
+            ...(trustedOidcToken
+              ? { "x-vercel-trusted-oidc-idp-token": trustedOidcToken }
+              : {}),
+            ...(bypassSecret
+              ? { "x-vercel-protection-bypass": bypassSecret }
+              : {}),
+          },
+        }
       : {}),
   },
   projects: [

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,0 +1,63 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { chromium } from "@playwright/test";
+
+// One-time bypass-cookie bootstrap for Vercel Deployment Protection.
+//
+// Background: page-context `extraHTTPHeaders` (OIDC identity, bypass
+// header) cover page-initiated requests, but browser-initiated requests —
+// notably the service-worker script/update fetches — don't carry them, so
+// the gate can reject exactly the worker while the app itself loads. A
+// bypass COOKIE, once stamped, is attached by the browser to EVERY request
+// class for the host, closing that gap.
+//
+// Behavior:
+// - VERCEL_AUTOMATION_BYPASS_SECRET absent (normal local runs): writes an
+//   empty storage state and does nothing else — suite behavior identical.
+// - Present (CI): visits the cookie-setting endpoint once, then persists
+//   the resulting storage for all tests in this run.
+// - The secret is never printed and never written to disk; only the
+//   resulting (opaque) cookies land in the run-scoped state file, which is
+//   gitignored (see .gitignore: playwright/.auth/).
+const AUTH_DIR = join(process.cwd(), "playwright", ".auth");
+const STATE_PATH = join(AUTH_DIR, "state.json");
+
+async function globalSetup(): Promise<void> {
+  await mkdir(AUTH_DIR, { recursive: true });
+  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (!secret) {
+    await writeFile(STATE_PATH, JSON.stringify({ cookies: [], origins: [] }));
+    return;
+  }
+  const baseURL = (process.env.BASE_URL ?? "http://127.0.0.1:3000").replace(/\/$/, "");
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      const url =
+        `${baseURL}/?x-vercel-set-bypass-cookie=true` +
+        `&x-vercel-protection-bypass=${encodeURIComponent(secret)}`;
+      const response = await page
+        .goto(url, { waitUntil: "domcontentloaded", timeout: 60000 })
+        .catch(() => null);
+      // Observability only (never the secret, never values, never the
+      // body): always report the endpoint status plus whether a bypass
+      // cookie is actually present afterwards. A 302 here sets NO cookie —
+      // only names are logged, values never leave the browser profile.
+      const status = response?.status() ?? -1;
+      const names = (await context.cookies()).map((c) => c.name);
+      const stamped = names.some((n) => /vercel|bypass/i.test(n));
+      console.log(
+        `[auth-setup] cookie endpoint HTTP ${status}; bypass cookie present: ${stamped} (cookies: ${names.join(",") || "none"})`,
+      );
+      await context.storageState({ path: STATE_PATH });
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;


### PR DESCRIPTION
Split from original #45 — auth + required prod behavior only. Test hardening moved to #46.

## Problem
Preview deploys behind Vercel Deployment Protection (anonymous -> 302 SSO).
- Playwright extraHTTPHeaders (OIDC + bypass) cover page-initiated requests only.
- Browser-initiated SW script/update fetches carry no page headers, so the worker can stay gated while the app loads.
- Once bypass headers are added, Leaflet tile <img> requests to *.basemaps.cartocdn.com also carry them -> CORS preflight -> CARTO rejects -> tile cache never fills, plus credential leak to CDN.

## Fix (7 files)
- .github/workflows/e2e.yml: auth-probe step (status codes only), VERCEL_AUTOMATION_BYPASS_SECRET env. No secrets printed.
- playwright.config.ts: bypass header, globalSetup, storageState, failure forensics (screenshot/trace only-on-failure).
- tests/global-setup.ts (new): stamps bypass cookie once per run via ?x-vercel-set-bypass-cookie endpoint; writes empty state locally; never prints/writes secret; gitignored via playwright/.auth/.
- .gitignore: playwright/.auth/.
- app/sw.ts: strip first-party auth headers before cartoTileStrategy.handle; headerless traffic skips rebuild; URL cache key untouched.
- lib/map/carto-tiles.ts: TILE_STRIP_HEADERS (exact 2 Vercel headers) + stripTileAuthHeaders helper.
- lib/map/carto-tiles.test.ts: strip unit tests (remove both + preserve accept, no-op false, exact list).

## Safety
- No user-facing offline regression: matcher/strategy/cache names/skipWaiting:false/clientsClaim/activate cleanup unchanged.
- Existing workers migrate safely: no cache rename, no precache change; old workers (never have these headers) unaffected until natural activation.
- Strip scope: only the 2 CI headers; normal users no-op. Verified: vitest lib/map/carto-tiles.test.ts 13/13 pass.
- No playwright/.auth files tracked; only ${{ secrets.* }} / process.env refs, no values.

## Split
- This PR = PR-A (auth/bypass fix), branch ci/e2e-bypass-cookie-and-tile-waits at f9b0094.
- PR-B = #46 (tile-test readiness waits, tests/ only). For preview CI, run B after / rebase over this PR.