### PR TITLE
test(e2e): tile-test readiness waits + offline hardening

### DIFF
--- a/tests/map-reconnect.spec.ts
+++ b/tests/map-reconnect.spec.ts
@@ -325,6 +325,21 @@ test.describe("Map reconnect recovery", () => {
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
     await waitForOfflineReady(page);
+    // Deterministic precondition: seed one tile entry directly so the
+    // offline half never depends on third-party tile timing. Natural
+    // end-to-end caching is map-tiles.spec.ts's job; this test's claim is
+    // the banner behavior with a non-empty tile cache. (Zooming below is
+    // kept so the map still issues real tile requests-shaped traffic.)
+    await page.evaluate(async () => {
+      const res = await fetch(
+        "https://a.basemaps.cartocdn.com/dark_nolabels/11/1315/806.png",
+      );
+      const cache = await caches.open("metto-carto-tiles");
+      await cache.put(
+        "https://a.basemaps.cartocdn.com/dark_nolabels/11/1315/806.png",
+        res.clone(),
+      );
+    });
     // Same nudge: ensure post-control tile requests exist to cache.
     await page.getByRole("button", { name: "Zoom in" }).click();
     await page.waitForTimeout(1500);
@@ -370,6 +385,11 @@ test.describe("Map reconnect recovery", () => {
     await expect(
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
+    // A controlling worker is the prerequisite for the offline reload
+    // below (the precache fallback is served only by the worker). Fresh
+    // test profiles install ~8MB on first visit; without this wait the
+    // reload can land before activation and fail at the network layer.
+    await waitForOfflineReady(page);
 
     // First online visit: informational notice, info styling, no cache words.
     await expect(

--- a/tests/map-tiles.spec.ts
+++ b/tests/map-tiles.spec.ts
@@ -39,6 +39,27 @@ async function tileUrls(page: {
   });
 }
 
+// A controlling worker is the prerequisite for every tile-cache assertion
+// below (entries are written only inside the worker). Fresh test profiles
+// install ~8MB on first visit; polling here instead of assuming install won
+// before the first zoom keeps slow (CI) networks green.
+async function waitForSWControl(page: {
+  evaluate: <T>(fn: () => Promise<T> | T) => Promise<T>;
+}): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(
+          () =>
+            typeof navigator !== "undefined" &&
+            "serviceWorker" in navigator &&
+            !!navigator.serviceWorker.controller,
+        ),
+      { timeout: 60_000 },
+    )
+    .toBe(true);
+}
+
 async function foreignCachedUrls(page: {
   evaluate: <T>(fn: () => Promise<T> | T) => Promise<T>;
 }): Promise<string[]> {
@@ -88,6 +109,7 @@ test.describe("CARTO opportunistic tile cache", () => {
     await expect(
       page.locator('[aria-label="Tehran metro on real map"]'),
     ).toBeVisible({ timeout: 30_000 });
+    await waitForSWControl(page);
 
     // Generate naturally-viewed tiles by zooming (no prefetch anywhere).
     await page.getByRole("button", { name: "Zoom in" }).click();
@@ -169,15 +191,30 @@ test.describe("CARTO opportunistic tile cache", () => {
       offlinePage.getByText("بدون اینترنت", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
 
-    // Cached tile returns 200 offline (served by the worker cache).
-    const cachedStatus = await offlinePage.evaluate(async (u) => {
-      const res = await fetch(u);
-      return res.status;
-    }, urls[0]);
-    expect(cachedStatus).toBe(200);
+    // Cached tile loads offline (served by the worker cache). Loaded as an
+    // image — the same destination ("image") Leaflet uses — so the request
+    // actually routes through the worker: a bare fetch() carries
+    // destination "" and never matches the tile route (it only ever passed
+    // via the incidental HTTP cache).
+    const cachedLoads = await offlinePage.evaluate(
+      (u) =>
+        new Promise<boolean>((resolve) => {
+          const img = new Image();
+          img.crossOrigin = "anonymous";
+          img.onload = () => resolve(true);
+          img.onerror = () => resolve(false);
+          img.src = u;
+        }),
+      urls[0],
+    );
+    expect(cachedLoads).toBe(true);
 
     // Uncached tile offline: handled failure (fetch rejects to the caller),
-    // no unhandled Serwist rejection, banner remains.
+    // no unhandled Serwist rejection, banner remains. Deliberately a bare
+    // fetch(), not an image: worker-subrequest fetches are not covered by
+    // offline emulation, so an image load here would succeed over the live
+    // network and prove nothing — while a page-initiated fetch is genuinely
+    // offline and must reject.
     const miss = await offlinePage.evaluate(async () => {
       try {
         const res = await fetch(


### PR DESCRIPTION
Split from #45 — test reliability only, no production changes.

## Scope (2 files)
- tests/map-tiles.spec.ts: waitForSWControl (60s controller poll before zoom), cached-tile assertion via Image load (destination image routes through worker; bare fetch does not), miss check stays bare fetch with clarifying comment.
- tests/map-reconnect.spec.ts: seed one tile entry directly so offline half does not depend on third-party timing; extra waitForOfflineReady before offline reload.

## Why separate from #45
#45 keeps Vercel bypass-cookie auth + required SW tile header stripping. These waits fix generic slow-install flakiness (fresh profiles install ~8MB) and fail locally too — orthogonal to the auth gate.

## Safety
- No app/ or lib/ changes; no secrets; no Vercel strings in diff.
- Base: main (a080bbf). For preview CI runs, run after / rebase over #45 so the Deployment Protection gate is open.