### PR TITLE
fix(rtl): Persian origin/dest placeholder aligns right

### DIFF
--- a/components/station-combobox.tsx
+++ b/components/station-combobox.tsx
@@ -159,7 +159,7 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
           className="flex min-w-0 flex-1 items-center gap-2 rounded-lg px-3 py-2.5 text-start transition-colors hover:bg-accent/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background md:px-4 md:py-3"
         >
           <span className={cn("size-2.5 shrink-0 rounded-full", accentClass)} aria-hidden="true" />
-          <span className="min-w-0 flex-1 truncate">
+          <span className="min-w-0 flex-1 truncate" dir={isFa ? "rtl" : "ltr"}>
             {selected ? (
               <span className="flex items-center gap-2">
                 <span className="truncate font-medium">{isFa ? selected.name.fa : selected.name.en}</span>
@@ -197,13 +197,13 @@ export function StationCombobox({ value, onChange, onPlaceSelect, placeholder, l
               aria-expanded={open}
               aria-controls={listboxId}
               aria-autocomplete="list"
-              dir="auto"
-              className="ios-no-zoom-input w-full rounded-md bg-muted px-3 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background md:px-4 md:py-2.5 md:text-base"
+              dir={isFa ? "rtl" : "ltr"}
+              className="ios-no-zoom-input w-full rounded-md bg-muted px-3 py-2 text-start text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background md:px-4 md:py-2.5 md:text-base"
             />
           </div>
           <ul id={listboxId} role="listbox" aria-label={placeholder} className="max-h-64 overflow-y-auto py-1">
             {query.length === 0 && onPlaceSelect && (
-              <li role="presentation" className="px-3 py-2 text-center text-xs text-muted-foreground md:px-4 md:py-2.5 md:text-sm">
+              <li role="presentation" dir={isFa ? "rtl" : "ltr"} className="px-3 py-2 text-center text-xs text-muted-foreground md:px-4 md:py-2.5 md:text-sm">
                 {STRINGS[lang].searchHintBefore}{" "}
                 <button
                   type="button"

--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -234,14 +234,14 @@ test.describe("Offline bottom navigation", () => {
       .getByRole("button", { name: /ایستگاه یا نام مکان/ })
       .first()
       .click();
-    await page.locator('input[dir="auto"]').first().fill("تجریش");
+    await page.getByRole("combobox").first().fill("تجریش");
     await page.getByRole("button", { name: /تجریش/ }).first().click();
     await expect(page).toHaveURL(/from=tajrish/, { timeout: 15_000 });
     await page
       .getByRole("button", { name: /ایستگاه یا نام مکان/ })
       .first()
       .click();
-    await page.locator('input[dir="auto"]').first().fill("تهران (صادقیه)");
+    await page.getByRole("combobox").first().fill("تهران (صادقیه)");
     await page.getByRole("button", { name: /تهران/ }).first().click();
     const mapHref =
       (await tabLink(page, "نقشه").getAttribute("href")) ?? "";

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -108,7 +108,7 @@ test.describe("Metto offline PWA", () => {
       name: /ایستگاه یا نام مکان/,
     });
     await originToggle.first().click();
-    const searchInput = page.locator('input[dir="auto"]').first();
+    const searchInput = page.getByRole("combobox").first();
     await searchInput.fill(ORIGIN_FA);
     await page
       .getByRole("button", { name: new RegExp(ORIGIN_FA) })
@@ -189,12 +189,12 @@ test.describe("Metto offline PWA", () => {
       .getByRole("button", { name: /ایستگاه یا نام مکان/ })
       .first()
       .click();
-    await page.locator('input[dir="auto"]').first().fill("Iran Mall");
+    await page.getByRole("combobox").first().fill("Iran Mall");
     await expect(
       page.getByText("برای جستجوی مکان به اینترنت نیاز است."),
     ).toBeVisible({ timeout: 15_000 });
     // Station search still works alongside the offline place note.
-    await page.locator('input[dir="auto"]').first().fill(ORIGIN_FA);
+    await page.getByRole("combobox").first().fill(ORIGIN_FA);
     await expect(
       page.getByRole("button", { name: new RegExp(ORIGIN_FA) }).first(),
     ).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
Closes #48.

## What
Persian placeholder `ایستگاه یا نام مکان…` in Origin/Dest rendered left-aligned (LTR) in the empty pre-type state.

## Why
`StationCombobox` search `<input>` used `dir="auto"`, which falls back to LTR when the value is empty, so the fa placeholder never got RTL direction. No explicit text alignment either.

## Changes
- `components/station-combobox.tsx`: explicit `dir={isFa ? "rtl" : "ltr"}` on search input (+ `text-start`), trigger placeholder wrapper, and empty-query hint row.
- `tests/offline.spec.ts`, `tests/offline-nav.spec.ts`: `input[dir="auto"]` selectors -> `getByRole("combobox")` (robust to dir changes).

## Verify
- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` on touched files: 0 errors (2 pre-existing warnings)
- [x] `pnpm test`: 18 files / 213 tests pass
- [ ] Manual: fa Origin/Dest collapsed + opened empty input right-aligned; en unchanged