### PR TITLE
ci(e2e): descriptive run-name for Vercel and manual preview runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,7 @@
 # already exist on the default branch, so the first real Vercel-triggered
 # run happens after this file merges. Until then, use workflow_dispatch.
 name: E2E (offline)
+run-name: Preview E2E ${{ github.event.client_payload.environment || 'manual' }} @ ${{ github.event.client_payload.git.sha || github.sha }} - ${{ inputs.base_url || github.event.client_payload.url }}
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Closes #53.

Vercel-triggered runs currently show as `vercel.deployment.success #N` (e.g. https://github.com/aliinreallife/metto/actions/runs/34692909115) because `E2E (offline)` sets no `run-name:` and GitHub falls back to `<dispatch type> #<run_number>`.

Change: add `run-name: Preview E2E <environment|manual> @ <sha> - <url>` covering both `repository_dispatch` and `workflow_dispatch`. No change to `on.repository_dispatch.types` (Vercel contract).

Verification: YAML parses (`python3 -c yaml.safe_load`). New name applies to runs triggered after merge to `main`; existing run titles are immutable.