### PR TITLE
test(e2e): locate combobox by accessible label name and option role

### DIFF
--- a/tests/offline-nav.spec.ts
+++ b/tests/offline-nav.spec.ts
@@ -230,19 +230,21 @@ test.describe("Offline bottom navigation", () => {
 
     // Create route context WITHOUT navigating: combobox selection updates
     // tab hrefs client-side to arbitrary (non-hardcoded) values.
+    // Trigger names come from the associated <label>s (مبدأ/مقصد), not the
+    // placeholder content; dropdown items are role=option since #44.
     await page
-      .getByRole("button", { name: /ایستگاه یا نام مکان/ })
+      .getByRole("button", { name: "مبدأ", exact: true })
       .first()
       .click();
     await page.getByRole("combobox").first().fill("تجریش");
-    await page.getByRole("button", { name: /تجریش/ }).first().click();
+    await page.getByRole("option", { name: /تجریش/ }).first().click();
     await expect(page).toHaveURL(/from=tajrish/, { timeout: 15_000 });
     await page
-      .getByRole("button", { name: /ایستگاه یا نام مکان/ })
+      .getByRole("button", { name: "مقصد", exact: true })
       .first()
       .click();
     await page.getByRole("combobox").first().fill("تهران (صادقیه)");
-    await page.getByRole("button", { name: /تهران/ }).first().click();
+    await page.getByRole("option", { name: /تهران/ }).first().click();
     const mapHref =
       (await tabLink(page, "نقشه").getAttribute("href")) ?? "";
     expect(mapHref).toContain("from=tajrish");

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -104,14 +104,17 @@ test.describe("Metto offline PWA", () => {
     ).toHaveCount(0);
 
     // 5-7. Interactive station select + route calc (origin via combobox).
+    // Trigger name comes from the associated <label> (مبدأ), not the
+    // placeholder content; dropdown items are role=option since #44.
     const originToggle = page.getByRole("button", {
-      name: /ایستگاه یا نام مکان/,
+      name: "مبدأ",
+      exact: true,
     });
     await originToggle.first().click();
     const searchInput = page.getByRole("combobox").first();
     await searchInput.fill(ORIGIN_FA);
     await page
-      .getByRole("button", { name: new RegExp(ORIGIN_FA) })
+      .getByRole("option", { name: new RegExp(ORIGIN_FA) })
       .first()
       .click();
     await expect(page).toHaveURL(new RegExp(`from=${ORIGIN_ID}`), {
@@ -186,7 +189,7 @@ test.describe("Metto offline PWA", () => {
     // 18-20. Landmark search explains the Internet requirement offline.
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await page
-      .getByRole("button", { name: /ایستگاه یا نام مکان/ })
+      .getByRole("button", { name: "مبدأ", exact: true })
       .first()
       .click();
     await page.getByRole("combobox").first().fill("Iran Mall");
@@ -196,7 +199,7 @@ test.describe("Metto offline PWA", () => {
     // Station search still works alongside the offline place note.
     await page.getByRole("combobox").first().fill(ORIGIN_FA);
     await expect(
-      page.getByRole("button", { name: new RegExp(ORIGIN_FA) }).first(),
+      page.getByRole("option", { name: new RegExp(ORIGIN_FA) }).first(),
     ).toBeVisible({ timeout: 15_000 });
 
     // 21-23. Timetable renders offline from the local dataset with the


### PR DESCRIPTION
Fixes the 2 remaining E2E failures (offline-nav cold query navigations, offline cold restart) — both died in the ONLINE setup phase waiting 120s for `getByRole('button', { name: /ایستگاه یا نام مکان/ })`.

## Root cause
Not cold boot, precache, RTL (#49), or flake. PR #44 associated the triggers with `<label>`s (`مبدأ`/`مقصد`, `app/home-page.tsx:402,449`) and gave dropdown items `role=option`. Chromium therefore names the trigger from the label, so the pre-#44 placeholder-name query matches zero nodes forever, and item queries as `role=button` are stale too. Proven live: Chrome AX lists the triggers as مبدأ/مقصد while the old query resolves nothing on a DOM-perfect page.

## Changes (tests only, no app code)
- Triggers: `{ name: /ایستگاه یا نام مکان/ }` -> `{ name: "مبدأ" / "مقصد", exact: true }`
- Items: `getByRole("button", station)` -> `getByRole("option", station)`
- `getByRole("combobox")` unchanged (works)

## Verify
- [x] Corrected locators drive origin->dest->route end-to-end on a local prod build, no pageerrors
- [x] `pnpm eslint` clean, `pnpm typecheck` clean, `pnpm test` 18 files / 213 tests pass
- [x] Pristine-code control: unrelated local-only failure also fails without this change (sandbox browser limitation, see below)
- [ ] Preview E2E on this PR's deployment (authoritative; local sandbox can't run bundled Chromium **and** loses offline emulation on page recreation with system Chromium, so cold-restart steps must validate in CI)