### PR TITLE
chore(ci): pin all workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -49,10 +49,10 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,24 +77,24 @@ jobs:
       BASE_URL: ${{ inputs.base_url || github.event.client_payload.url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Exact deployed commit for Vercel events; the dispatched branch
           # head for manual runs (an empty ref input keeps default behavior).
           ref: ${{ github.event.client_payload.git.sha }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
 
       - name: Mint OIDC token for Vercel Trusted Sources
         id: oidc
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           # Default audience (https://github.com/<account>) matches the
           # dashboard rule; the token is masked and never printed.
@@ -128,7 +128,7 @@ jobs:
           echo "Metto Preview E2E status target: $SHA"
 
       - name: Mark Metto Preview E2E pending
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-failure-artifacts
           if-no-files-found: ignore
@@ -192,7 +192,7 @@ jobs:
       # Cancelled/aborted runs report `error` — neither green nor red.
       - name: Report Metto Preview E2E success
         if: success() && steps.target.outputs.sha != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -207,7 +207,7 @@ jobs:
 
       - name: Report Metto Preview E2E failure
         if: failure() && steps.target.outputs.sha != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -222,7 +222,7 @@ jobs:
 
       - name: Report Metto Preview E2E cancelled
         if: cancelled() && steps.target.outputs.sha != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             await github.rest.repos.createCommitStatus({


### PR DESCRIPTION
Pins the remaining tag-based action references in ci.yml (5) and e2e.yml (10) to the current tip SHAs of their major lines, each with a version comment. No major upgrades, no behavior change. android-release.yml, android-ci.yml, and prepare-release.yml were already pinned (verified by full audit — no @vX refs remain anywhere under .github/workflows/).

Release notes: none